### PR TITLE
Add logging support

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -1,11 +1,16 @@
+use anyhow::{Context, Result};
+use conmon::{
+    conmon_server::{Conmon, ConmonServer},
+    VersionRequest, VersionResponse,
+};
+use derive_builder::Builder;
+use env_logger::fmt::Color;
+use getset::{Getters, MutGetters};
+use log::{info, LevelFilter};
+use std::{env, io::Write};
 use tonic::{transport::Server, Request, Response, Status};
 
 mod config;
-
-use conmon::conmon_server::{Conmon, ConmonServer};
-use conmon::{VersionRequest, VersionResponse};
-use derive_builder::Builder;
-use getset::{Getters, MutGetters};
 
 const VERSION: &str = "0.1.0";
 
@@ -21,13 +26,53 @@ pub struct ConmonServerImpl {
     config: config::Config,
 }
 
+impl ConmonServerImpl {
+    /// Create a new ConmonServerImpl instance.
+    pub fn new() -> Result<Self> {
+        let server = Self::default();
+        server.init_logging().context("set log verbosity")?;
+        Ok(server)
+    }
+
+    fn init_logging(&self) -> Result<()> {
+        let level = self.config.log_level().to_string();
+        env::set_var("RUST_LOG", level);
+
+        // Initialize the logger with the format:
+        // [YYYY-MM-DDTHH:MM:SS:MMMZ LEVEL crate::module file:LINE] MSG…
+        // The file and line will be only printed when running with debug or trace level.
+        let log_level = self.config.log_level();
+        env_logger::builder()
+            .format(move |buf, r| {
+                let mut style = buf.style();
+                style.set_color(Color::Black).set_intense(true);
+                writeln!(
+                    buf,
+                    "{}{} {:<5} {}{}{} {}",
+                    style.value("["),
+                    buf.timestamp_millis(),
+                    buf.default_styled_level(r.level()),
+                    r.target(),
+                    match (log_level >= LevelFilter::Debug, r.file(), r.line()) {
+                        (true, Some(file), Some(line)) => format!(" {}:{}", file, line),
+                        _ => "".into(),
+                    },
+                    style.value("]"),
+                    r.args()
+                )
+            })
+            .try_init()
+            .context("init env logger")
+    }
+}
+
 #[tonic::async_trait]
 impl Conmon for ConmonServerImpl {
     async fn version(
         &self,
         request: Request<VersionRequest>,
     ) -> Result<Response<VersionResponse>, Status> {
-        println!("Got a request: {:?}", request);
+        info!("Got a request: {:?}", request);
 
         let res = VersionResponse {
             version: String::from(VERSION),
@@ -40,7 +85,7 @@ impl Conmon for ConmonServerImpl {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "[::1]:50051".parse()?;
-    let server = ConmonServerImpl::default();
+    let server = ConmonServerImpl::new()?;
 
     Server::builder()
         .add_service(ConmonServer::new(server))


### PR DESCRIPTION
We now add logging support via env_logger. This allows using the log
macros, for example `info!()` and prints useful debugging information
side by side to the log message:

```
[2021-11-05T09:58:18.590Z INFO  conmon_server src/server.rs:75] Got a request: Request { metadata: MetadataMap { headers: {"te": "trailers", "content-type": "application/grpc", "user-agent": "tonic/0.6.1"}  }, message: VersionRequest, extensions: Extensions  }
```
