### PR TITLE
Switch to single threaded tokio runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,16 +440,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "os_str_bytes"
 version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,7 +779,6 @@ dependencies = [
  "libc",
  "memchr",
  "mio",
- "num_cpus",
  "pin-project-lite",
  "tokio-macros",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ getset = "0.1.1"
 log = { version = "0.4.14", features = ["serde", "std"] }
 prost = "0.9.0"
 serde = { version = "1.0.130", features = ["derive"] }
-tokio = { version = "1.13.0", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.13.0", features = ["macros", "rt"] }
 tonic = "0.6.1"
 
 [build-dependencies]

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,11 +5,11 @@ pub mod conmon {
     tonic::include_proto!("conmon");
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut client = ConmonClient::connect("http://[::1]:50051").await?;
 
-    let req = tonic::Request::new(VersionRequest{});
+    let req = tonic::Request::new(VersionRequest {});
 
     let resp = client.version(req).await?;
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -81,7 +81,8 @@ impl Conmon for ConmonServerImpl {
     }
 }
 
-#[tokio::main]
+// Use the single threaded runtime to save rss memory
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "[::1]:50051".parse()?;
     let server = ConmonServerImpl::new()?;


### PR DESCRIPTION
This saves more than 50% RSS memory on runtime.

Before:
```
> cat /proc/(pidof conmon-server)/status | rg RSS
VmRSS:      3264 kB
```

After:
```
> cat /proc/(pidof conmon-server)/status | rg RSS
VmRSS:      1460 kB
```

Way better than: https://github.com/containers/conmon-rs/pull/8