### PR TITLE
Validate config before server start

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -65,7 +65,7 @@ impl Default for Config {
 
 impl Config {
     /// Validate the configuration integrity.
-    pub fn validate(&mut self) -> Result<()> {
+    pub fn validate(&self) -> Result<()> {
         if !self.runtime().exists() {
             bail!("runtime path '{}' does not exist", self.runtime().display())
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -31,6 +31,7 @@ impl ConmonServerImpl {
     pub fn new() -> Result<Self> {
         let server = Self::default();
         server.init_logging().context("set log verbosity")?;
+        server.config().validate().context("validate config")?;
         Ok(server)
     }
 


### PR DESCRIPTION
Before applying this patch the function was basically unused.