### PR TITLE
Switch to simple-logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,15 +86,28 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cc"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 
 [[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time",
+ "winapi",
+]
 
 [[package]]
 name = "clap"
@@ -127,19 +140,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "conmon-rs"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-stream",
  "clap",
- "env_logger",
  "futures",
  "getset",
  "log",
  "nix",
  "prost",
  "serde",
+ "simple_logger",
  "tokio",
  "tonic",
  "tonic-build",
@@ -151,19 +175,6 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
-
-[[package]]
-name = "env_logger"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
 
 [[package]]
 name = "fixedbitset"
@@ -372,12 +383,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "0.14.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,6 +528,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -806,6 +830,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_logger"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7de33c687404ec3045d4a0d437580455257c0436f858d702f244e7d652f9f07"
+dependencies = [
+ "atty",
+ "chrono",
+ "colored",
+ "log",
+ "winapi",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,6 +916,16 @@ checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
 dependencies = [
  "terminal_size",
  "unicode-width",
+]
+
+[[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ path = "src/client.rs"
 anyhow = "1.0.45"
 async-stream = "0.3.2"
 clap = { git = "https://github.com/clap-rs/clap", features = ["wrap_help"] }
-env_logger = "0.9.0"
 futures = "0.3.17"
 getset = "0.1.1"
 log = { version = "0.4.14", features = ["serde", "std"] }
 prost = "0.9.0"
 serde = { version = "1.0.130", features = ["derive"] }
+simple_logger = "1.13.0"
 tokio = { version = "1.13.0", features = ["fs", "macros", "process", "rt", "signal", "time"] }
 tonic = "0.6.1"
 tower = "0.4.10"

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,7 @@ pub struct Config {
         default_value("info"),
         env(concat!(prefix!(), "LOG_LEVEL")),
         long("log-level"),
+        short('l'),
         possible_values(["trace", "debug", "info", "warn", "error", "off"]),
         value_name("LEVEL")
     )]

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,11 +5,10 @@ use conmon::{
     conmon_server::{Conmon, ConmonServer},
     VersionRequest, VersionResponse,
 };
-use env_logger::fmt::Color;
 use futures::TryFutureExt;
 use getset::{Getters, MutGetters};
-use log::{debug, info, LevelFilter};
-use std::{env, io::Write, path::PathBuf};
+use log::{debug, info};
+use std::{env, path::PathBuf};
 use stream::Stream;
 use tokio::{
     fs,
@@ -49,34 +48,11 @@ impl ConmonServerImpl {
     }
 
     fn init_logging(&self) -> Result<()> {
-        let level = self.config.log_level().to_string();
-        env::set_var("RUST_LOG", level);
-
-        // Initialize the logger with the format:
-        // [YYYY-MM-DDTHH:MM:SS:MMMZ LEVEL crate::module file:LINE] MSG…
-        // The file and line will be only printed when running with debug or trace level.
-        let log_level = self.config.log_level();
-        env_logger::builder()
-            .format(move |buf, r| {
-                let mut style = buf.style();
-                style.set_color(Color::Black).set_intense(true);
-                writeln!(
-                    buf,
-                    "{}{} {:<5} {}{}{} {}",
-                    style.value("["),
-                    buf.timestamp_millis(),
-                    buf.default_styled_level(r.level()),
-                    r.target(),
-                    match (log_level >= LevelFilter::Debug, r.file(), r.line()) {
-                        (true, Some(file), Some(line)) => format!(" {}:{}", file, line),
-                        _ => "".into(),
-                    },
-                    style.value("]"),
-                    r.args()
-                )
-            })
-            .try_init()
-            .context("init env logger")
+        if let Some(level) = self.config().log_level().to_level() {
+            simple_logger::init_with_level(level).context("init logger")?;
+            info!("Set log level to {}", level);
+        }
+        Ok(())
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -10,7 +10,7 @@ use tokio::{
 };
 
 // The maximum amount of allowed VmRSS in Kilobytes
-const MAX_RSS_KB: u32 = 4000;
+const MAX_RSS_KB: u32 = 3500;
 
 // We assume that the tests run in release mode
 const SERVER_BINARY: &str = "target/release/conmon-server";


### PR DESCRIPTION
This should reduce the RSS memory usage and keep it constant over time
while logging.

Fixes https://github.com/containers/conmon-rs/issues/19