### PR TITLE
server: daemonize and write pidfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,7 @@ dependencies = [
  "nix",
  "serde",
  "simple_logger",
+ "tempfile",
  "tokio",
  "tokio-util",
 ]
@@ -380,6 +381,17 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -655,6 +667,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,6 +727,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +791,15 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "serde"
@@ -805,6 +881,20 @@ name = "temp-dir"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af547b166dd1ea4b472165569fc456cfb6818116f854690b0ff205e636523dab"
+
+[[package]]
+name = "tempfile"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rand",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
 
 [[package]]
 name = "termcolor"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ futures = "0.3.17"
 getset = "0.1.1"
 gettext-rs = "0.7.0"
 log = { version = "0.4.14", features = ["serde", "std"] }
+nix = "0.23.0"
 serde = { version = "1.0.130", features = ["derive"] }
 simple_logger = "1.13.0"
 tokio = { version = "1.14.0", features = ["fs", "macros", "net", "process", "rt", "signal", "time"] }
@@ -37,4 +38,3 @@ opt-level = "z"
 codegen-units = 1
 
 [dev-dependencies]
-nix = "0.23.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,4 @@ opt-level = "z"
 codegen-units = 1
 
 [dev-dependencies]
+tempfile = "3.2.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,11 +1,11 @@
 //! Configuration related structures
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use clap::{crate_version, Parser};
 use getset::{CopyGetters, Getters, Setters};
 use log::LevelFilter;
 use serde::{Deserialize, Serialize};
+use std::fs;
 use std::{env, path::PathBuf};
-use tokio::fs;
 
 macro_rules! prefix {
     () => {
@@ -74,20 +74,16 @@ impl Default for Config {
 
 impl Config {
     /// Validate the configuration integrity.
-    pub async fn validate(&self) -> Result<()> {
+    pub fn validate(&self) -> Result<()> {
         if !self.runtime().exists() {
             bail!("runtime path '{}' does not exist", self.runtime().display())
         }
 
         if self.socket().exists() {
-            fs::remove_file(self.socket())
-                .await
-                .context("remove existing socket file")?;
+            fs::remove_file(self.socket())?;
         }
         if let Some(parent) = self.socket().parent() {
-            fs::create_dir_all(parent)
-                .await
-                .context("ensure parent socket dir")?;
+            fs::create_dir_all(parent)?;
         }
 
         Ok(())

--- a/src/server.rs
+++ b/src/server.rs
@@ -40,14 +40,10 @@ pub struct ConmonServerImpl {
 
 impl ConmonServerImpl {
     /// Create a new ConmonServerImpl instance.
-    pub async fn new() -> Result<Self> {
+    pub fn new() -> Result<Self> {
         let server = Self::default();
         server.init_logging().context("set log verbosity")?;
-        server
-            .config()
-            .validate()
-            .await
-            .context("validate config")?;
+        server.config().validate().context("validate config")?;
 
         server.init_self()?;
         Ok(server)
@@ -83,6 +79,9 @@ impl conmon::Server for ConmonServerImpl {
 }
 
 fn main() -> Result<(), Error> {
+    // First, initialize the server so we have access to the config pre-fork.
+    let server = ConmonServerImpl::new()?;
+
     // We need to fork as early as possible, especially before setting up tokio.
     // If we don't, the child will have a strange thread space and we're at risk of deadlocking.
     // We also have to treat the parent as the child (as described in [1]) to ensure we don't
@@ -92,18 +91,16 @@ fn main() -> Result<(), Error> {
         ForkResult::Parent { child: _, .. } => {
             unsafe { _exit(0) };
         }
-        ForkResult::Child => println!("I'm a new child process"),
+        ForkResult::Child => (),
     }
     // Use the single threaded runtime to save rss memory.
     let rt = runtime::Builder::new_current_thread().enable_io().build()?;
-    rt.block_on(start_server())?;
+    rt.block_on(start_server(server))?;
     Ok(())
 }
 
-async fn start_server() -> Result<(), Error> {
+async fn start_server(server: ConmonServerImpl) -> Result<(), Error> {
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
-    let server = ConmonServerImpl::new().await?;
-
     let socket = server.config().socket().clone();
     tokio::spawn(start_sigterm_handler(socket, shutdown_tx));
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,6 +6,10 @@ use conmon_capnp::conmon;
 use futures::{AsyncReadExt, FutureExt};
 use getset::{Getters, MutGetters};
 use log::{debug, info};
+use nix::{
+    libc::_exit,
+    unistd::{fork, ForkResult},
+};
 use std::{env, path::PathBuf};
 use tokio::{
     fs,
@@ -78,9 +82,25 @@ impl conmon::Server for ConmonServerImpl {
     }
 }
 
-// Use the single threaded runtime to save rss memory
-#[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<(), Error> {
+fn main() -> Result<(), Error> {
+    // We need to fork as early as possible, especially before setting up tokio.
+    // If we don't, the child will have a strange thread space and we're at risk of deadlocking.
+    // We also have to treat the parent as the child (as described in [1]) to ensure we don't
+    // interrupt the child's execution.
+    // 1: https://docs.rs/nix/0.23.0/nix/unistd/fn.fork.html#safety
+    match unsafe { fork()? } {
+        ForkResult::Parent { child: _, .. } => {
+            unsafe { _exit(0) };
+        }
+        ForkResult::Child => println!("I'm a new child process"),
+    }
+    // Use the single threaded runtime to save rss memory.
+    let rt = runtime::Builder::new_current_thread().enable_io().build()?;
+    rt.block_on(start_server())?;
+    Ok(())
+}
+
+async fn start_server() -> Result<(), Error> {
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let server = ConmonServerImpl::new().await?;
 


### PR DESCRIPTION
A key aspect of conmon is that it runs independent of the parent that calls it. As such, we need to daemonize. To be able to be tracked by the parent, we also need to write the new child's pid to a file that the parent specifies, so it can be watched.

Interestingly, the RSS is greatly reduced when we do this:
```
 $ ./target/release/conmon-server --runtime /usr/bin/crun --conmon-pidfile=/tmp/pidfile
2021-11-12 14:41:28,540 INFO [conmon_server] Set log level to INFO
2021-11-12 14:41:28,540 INFO [conmon_server::init] Missing sufficient privileges to adjust OOM score
[pehunt@ovpn-114-123 conmon-rs(fork)]
 $ cat /proc/$(pidof conmon-server)/status | grep RSS
VmRSS:       248 kB
[pehunt@ovpn-114-123 conmon-rs(fork)]
 $ ./target/release/conmon-client --runtime /usr/bin/crun --conmon-pidfile=/tmp/pidfile
2021-11-12 14:42:27,787 INFO [conmon_server] Got a request: Request { metadata: MetadataMap { headers: {"te": "trailers", "content-type": "application/grpc", "user-agent": "tonic/0.6.1"} }, message: VersionRequest, extensions: Extensions }
Version: Response { metadata: MetadataMap { headers: {"content-type": "application/grpc", "date": "Fri, 12 Nov 2021 19:42:27 GMT", "grpc-status": "0"} }, message: VersionResponse { version: "0.1.0" }, extensions: Extensions }
[pehunt@ovpn-114-123 conmon-rs(fork)]
 $ cat /proc/$(pidof conmon-server)/status | grep RSS
VmRSS:      2296 kB

```

note: a side effect of this PR is that conmon-server must be terminated with pkill or the like, because it is no longer a child of the calling terminal.
