### PR TITLE
Add unit tests to init module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,14 +113,12 @@ jobs:
           CARGO_INCREMENTAL: '0'
           RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests'
           RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests'
-      # TODO: enable when we have tests
-      # - name: Coverage
-      #   uses: actions-rs/grcov@v0.1
-      #   with:
-      #     config: .github/grcov.yml
-      # - name: Upload Results
-      #   uses: codecov/codecov-action@v2
-      #
+      - name: Coverage
+        uses: actions-rs/grcov@v0.1
+        with:
+          config: .github/grcov.yml
+      - name: Upload Results
+        uses: codecov/codecov-action@v2
 
   test-integration:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,7 +183,7 @@ dependencies = [
 [[package]]
 name = "clap"
 version = "3.0.0-beta.5"
-source = "git+https://github.com/clap-rs/clap#568fd46096c5f73ca4ad09d46b75c958edebc78e"
+source = "git+https://github.com/clap-rs/clap#aeff599248d4c434259fc027711b1b4767189094"
 dependencies = [
  "atty",
  "bitflags",
@@ -192,7 +201,7 @@ dependencies = [
 [[package]]
 name = "clap_derive"
 version = "3.0.0-beta.5"
-source = "git+https://github.com/clap-rs/clap#568fd46096c5f73ca4ad09d46b75c958edebc78e"
+source = "git+https://github.com/clap-rs/clap#aeff599248d4c434259fc027711b1b4767189094"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -257,12 +266,26 @@ dependencies = [
  "getset",
  "libc",
  "log",
+ "mockall",
  "nix",
  "serde",
  "simple_logger",
+ "tempfile",
  "tokio",
  "tokio-util",
 ]
+
+[[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
+name = "downcast"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
 
 [[package]]
 name = "event-listener"
@@ -278,6 +301,21 @@ checksum = "b394ed3d285a429378d3b384b9eb1285267e7df4b166df24b7a6939a04dc392e"
 dependencies = [
  "instant",
 ]
+
+[[package]]
+name = "float-cmp"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fragile"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69a039c3498dc930fe810151a34ba0c1c70b02b8625035592e74432f678591f2"
 
 [[package]]
 name = "futures"
@@ -389,6 +427,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "getset"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,11 +544,38 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.8"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9b9524d5b9d60d55bd3f6ca13180cfc06b5d7e54df308c8842d3f66c914cc4"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "windows-sys",
+ "winapi",
+]
+
+[[package]]
+name = "mockall"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab571328afa78ae322493cacca3efac6a0f2e0a67305b4df31fd439ef129ac0"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e25b214433f669161f414959594216d8e6ba83b6679d3db96899c0b4639033"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -514,6 +590,12 @@ dependencies = [
  "libc",
  "memoffset",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "ntapi"
@@ -590,6 +672,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+
+[[package]]
+name = "predicates"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49cfaf7fdaa3bfacc6fa3e7054e65148878354a5cfddcf661df4c851f8021df"
+dependencies = [
+ "difference",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e35a3326b75e49aa85f5dc6ec15b41108cf5aee58eabb1f274dd18b73c2451"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338c7be2905b732ae3984a2f40032b5e94fd8f52505b186c7d4d68d193445df7"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,6 +758,81 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -719,6 +911,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "rand",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -738,6 +944,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
+
+[[package]]
 name = "textwrap"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,12 +961,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "wasi",
  "winapi",
 ]
 
@@ -842,9 +1053,9 @@ checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wepoll-ffi"
@@ -885,46 +1096,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82ca39602d5cbfa692c4b67e3bcbb2751477355141c1ed434c94da4186836ff6"
-dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52695a41e536859d5308cc613b4a022261a274390b25bd29dfff4bf08505f3c2"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54725ac23affef038fecb177de6c9bf065787c2f432f79e3c373da92f3e1d8a"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d5158a43cc43623c0729d1ad6647e62fa384a3d135fd15108d37c683461f64"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc31f409f565611535130cfe7ee8e6655d3fa99c1c61013981e491921b5ce954"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2b8c7cbd3bfdddd9ab98769f9746a7fad1bca236554cd032b78d768bc0e89f"

--- a/conmon-rs/server/Cargo.toml
+++ b/conmon-rs/server/Cargo.toml
@@ -22,3 +22,7 @@ tokio = { version = "1.14.0", features = ["fs", "macros", "net", "process", "rt"
 tokio-util = { version = "0.6.9", features = ["compat"] }
 nix = "0.23.0"
 libc = "0.2.108"
+
+[dev-dependencies]
+mockall = "0.10.2"
+tempfile = "3.2.0"

--- a/conmon-rs/server/src/init.rs
+++ b/conmon-rs/server/src/init.rs
@@ -1,28 +1,159 @@
 use anyhow::{bail, Result};
-use libc::{setlocale, LC_ALL};
+use libc::{c_char, c_int, setlocale, LC_ALL};
 use log::info;
-use std::ffi::CString;
-use std::fs::File;
-use std::io::{ErrorKind, Write};
+use std::{
+    ffi::CString,
+    fs::File,
+    io::{self, ErrorKind, Write},
+    path::Path,
+};
 
-/// Unset the locale for the current process.
-pub fn unset_locale() -> Result<()> {
-    unsafe {
-        setlocale(LC_ALL, CString::new("")?.as_ptr());
-    }
-    Ok(())
+#[cfg(test)]
+use mockall::{automock, predicate::*};
+
+#[derive(Debug, Default)]
+pub struct Init<T> {
+    imp: T,
 }
 
-/// Helper to adjust the OOM score of the currently running process.
-pub fn set_oom(score: &str) -> Result<()> {
-    // Attempt adjustment with best-effort.
-    if let Err(err) = File::create("/proc/self/oom_score_adj")?.write_all(score.as_bytes()) {
-        match err.kind() {
-            ErrorKind::PermissionDenied => {
-                info!("Missing sufficient privileges to adjust OOM score")
-            }
-            _ => bail!("adjusting OOM score {}", err),
-        }
+impl<T> Init<T>
+where
+    T: InitImpl,
+{
+    /// Unset the locale for the current process.
+    pub fn unset_locale(&self) -> Result<()> {
+        self.imp.setlocale(LC_ALL, CString::new("")?.as_ptr());
+        Ok(())
     }
-    Ok(())
+
+    /// Helper to adjust the OOM score of the currently running process.
+    pub fn set_oom_score<S: AsRef<str>>(&self, score: S) -> Result<()> {
+        // Attempt adjustment with best-effort.
+        let mut file = self.imp.create_file("/proc/self/oom_score_adj")?;
+        if let Err(err) = self
+            .imp
+            .write_all_file(&mut file, score.as_ref().as_bytes())
+        {
+            match err.kind() {
+                ErrorKind::PermissionDenied => {
+                    info!("Missing sufficient privileges to adjust OOM score")
+                }
+                _ => bail!("adjusting OOM score {}", err),
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg_attr(test, automock)]
+pub trait InitImpl {
+    fn setlocale(&self, category: c_int, locale: *const c_char) -> *mut c_char;
+    fn create_file<P: 'static + AsRef<Path>>(&self, path: P) -> io::Result<File>;
+    fn write_all_file(&self, file: &mut File, buf: &[u8]) -> io::Result<()>;
+}
+
+#[derive(Debug, Default)]
+pub struct DefaultInit;
+
+impl InitImpl for DefaultInit {
+    fn setlocale(&self, category: c_int, locale: *const c_char) -> *mut c_char {
+        unsafe { setlocale(category, locale) }
+    }
+
+    fn create_file<P: AsRef<Path>>(&self, path: P) -> io::Result<File> {
+        File::create(path)
+    }
+
+    fn write_all_file(&self, file: &mut File, buf: &[u8]) -> io::Result<()> {
+        file.write_all(buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{ptr, str};
+    use tempfile::tempfile;
+
+    fn new_sut(mock: MockInitImpl) -> Init<MockInitImpl> {
+        let mut sut = Init::<MockInitImpl>::default();
+        sut.imp = mock;
+        sut
+    }
+
+    #[test]
+    fn unset_locale() -> Result<()> {
+        let mut mock = MockInitImpl::new();
+        mock.expect_setlocale()
+            .withf(|x, _| *x == LC_ALL)
+            .returning(|_, _| ptr::null_mut());
+
+        let sut = new_sut(mock);
+
+        sut.unset_locale()
+    }
+
+    #[test]
+    fn set_oom_success() -> Result<()> {
+        let mut mock = MockInitImpl::new();
+
+        mock.expect_create_file()
+            .with(eq("/proc/self/oom_score_adj"))
+            .returning(|_: &str| tempfile());
+
+        mock.expect_write_all_file()
+            .withf(|_, x| x == "-1000".as_bytes())
+            .returning(|_, _| Ok(()));
+
+        let sut = new_sut(mock);
+        sut.set_oom_score("-1000")
+    }
+
+    #[test]
+    fn set_oom_success_write_all_fails_permission_denied() -> Result<()> {
+        let mut mock = MockInitImpl::new();
+
+        mock.expect_create_file()
+            .with(eq("/proc/self/oom_score_adj"))
+            .returning(|_: &str| tempfile());
+
+        mock.expect_write_all_file()
+            .withf(|_, x| x == "-1000".as_bytes())
+            .returning(|_, _| Err(io::Error::new(ErrorKind::PermissionDenied, "")));
+
+        let sut = new_sut(mock);
+        sut.set_oom_score("-1000")
+    }
+
+    #[test]
+    fn set_oom_failed_create_file() {
+        let mut mock = MockInitImpl::new();
+
+        mock.expect_create_file()
+            .with(eq("/proc/self/oom_score_adj"))
+            .returning(|_: &str| Err(io::Error::new(ErrorKind::Other, "")));
+
+        let sut = new_sut(mock);
+        let res = sut.set_oom_score("-1000");
+
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn set_oom_failed_write_all_file() {
+        let mut mock = MockInitImpl::new();
+
+        mock.expect_create_file()
+            .with(eq("/proc/self/oom_score_adj"))
+            .returning(|_: &str| tempfile());
+
+        mock.expect_write_all_file()
+            .withf(|_, x| x == "-1000".as_bytes())
+            .returning(|_, _| Err(io::Error::new(ErrorKind::Other, "")));
+
+        let sut = new_sut(mock);
+        let res = sut.set_oom_score("-1000");
+
+        assert!(res.is_err());
+    }
 }

--- a/conmon-rs/server/src/lib.rs
+++ b/conmon-rs/server/src/lib.rs
@@ -1,3 +1,4 @@
+use crate::init::{DefaultInit, Init};
 use anyhow::{Context, Result};
 use capnp_rpc::{rpc_twoparty_capnp::Side, twoparty, RpcSystem};
 use conmon_common::conmon_capnp::conmon;
@@ -67,10 +68,11 @@ impl Server {
     }
 
     fn init_self(&self) -> Result<()> {
-        init::unset_locale()?;
+        let init = Init::<DefaultInit>::default();
+        init.unset_locale()?;
         // While we could configure this, standard practice has it as -1000,
         // so it may be YAGNI to add configuration.
-        init::set_oom("-1000")?;
+        init.set_oom_score("-1000")?;
         Ok(())
     }
 


### PR DESCRIPTION
To be able to test the init functions, we require a wrapping structure
and replace-able implementation for it. This has been now added, while
the default init implementation is being used from the server.
