### PR TITLE
enables multi threaded scheduler again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,6 +601,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "objc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -877,6 +887,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "num_cpus",
  "once_cell",
  "pin-project-lite",
  "signal-hook-registry",

--- a/conmon-rs/server/Cargo.toml
+++ b/conmon-rs/server/Cargo.toml
@@ -19,6 +19,6 @@ gettext-rs = "0.7.0"
 log = { version = "0.4.14", features = ["serde", "std"] }
 serde = { version = "1.0.130", features = ["derive"] }
 simple_logger = "1.13.0"
-tokio = { version = "1.14.0", features = ["fs", "macros", "net", "process", "rt", "signal", "time"] }
+tokio = { version = "1.14.0", features = ["fs", "macros", "rt-multi-thread", "net", "process", "signal", "time"] }
 tokio-util = { version = "0.6.9", features = ["compat"] }
 nix = "0.23.0"

--- a/conmon-rs/server/src/lib.rs
+++ b/conmon-rs/server/src/lib.rs
@@ -61,8 +61,8 @@ impl Server {
         }
 
         // Use the single threaded runtime to save rss memory.
-        let rt = runtime::Builder::new_current_thread().enable_io().build()?;
-        rt.block_on(self.spawn_tasks())?;
+        let mt = runtime::Builder::new_multi_thread().enable_all().build()?;
+        mt.block_on(self.spawn_tasks())?;
         Ok(())
     }
 


### PR DESCRIPTION
With the migration to capnproto, I enabled the multithreaded tokio scheduler again. RSS is at 1.4 MB on my machine. Might be worth it based on todays discussion on managing multiple log streams.