### PR TITLE
Fix double usage of `-r` flag

### DIFF
--- a/conmon-rs/server/src/config.rs
+++ b/conmon-rs/server/src/config.rs
@@ -58,7 +58,6 @@ pub struct Config {
     #[clap(
         env(concat!(prefix!(), "RUNTIME_ROOT")),
         long("runtime-root"),
-        short('r'),
         value_name("RUNTIME_ROOT")
     )]
     /// Path of the OCI runtime to use to operate on the containers.


### PR DESCRIPTION
This causes a runtime panic on server startup.