### PR TITLE
ci: build against Minimum Supported Rust Version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   GO_VERSION: '1.17'
+  ACTION_MSRV_TOOLCHAIN: 1.54.0
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -25,7 +26,8 @@ jobs:
       - name: Select Nighly Toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: ${{ env['ACTION_MSRV_TOOLCHAIN']  }}
+          default: true
           override: true
           components: rustfmt
       - run: cargo build
@@ -47,7 +49,8 @@ jobs:
       - name: Select Nighly Toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: ${{ env['ACTION_MSRV_TOOLCHAIN']  }}
+          default: true
           override: true
           components: rustfmt
       - name: Cargo doc
@@ -70,7 +73,8 @@ jobs:
       - name: Select Nighly Toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: ${{ env['ACTION_MSRV_TOOLCHAIN']  }}
+          default: true
           override: true
           components: clippy, rustfmt
       - name: Clippy Lint
@@ -84,7 +88,8 @@ jobs:
       - name: Select Nighly Toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: ${{ env['ACTION_MSRV_TOOLCHAIN']  }}
+          default: true
           override: true
           components: rustfmt
       - name: Rustfmt

--- a/conmon-rs/client/Cargo.toml
+++ b/conmon-rs/client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "conmon-client"
 version = "0.1.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 async-io = "1.6.0"

--- a/conmon-rs/common/Cargo.toml
+++ b/conmon-rs/common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "conmon-common"
 version = "0.1.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 capnp = "0.14.3"

--- a/conmon-rs/server/Cargo.toml
+++ b/conmon-rs/server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "conmon-server"
 version = "0.1.0"
-edition = "2021"
+edition = "2018"
 
 [[bin]]
 name = "conmon-server"


### PR DESCRIPTION
to make sure we're compatible with slow-moving distros
heavily based off of https://github.com/ostreedev/ostree-rs-ext/pull/173/ thanks @lucab

Signed-off-by: Peter Hunt <pehunt@redhat.com>