### PR TITLE
Remove unnecessary arc clone

### DIFF
--- a/conmon-rs/server/src/child_reaper.rs
+++ b/conmon-rs/server/src/child_reaper.rs
@@ -25,7 +25,6 @@ impl ChildReaper {
                     waitpid(Pid::from_raw(-1), None)
                 };
 
-                let grandchildren = Arc::clone(&grandchildren);
                 match wait_status {
                     Ok(status) => {
                         if let WaitStatus::Exited(grandchild_pid, exit_status) = status {


### PR DESCRIPTION
We do not need to clone it twice hence one of them can be removed before
moving it into the thread.