### PR TITLE
Cache integration test files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,14 +133,22 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup Cache
+      - name: Setup Rust and Golang Cache
         uses: actions/cache@v2
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-test-integration-${{ hashFiles('**/Cargo.lock') }}
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-cargo-test-integration-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/go.sum') }}
+      - name: Setup Testfiles Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            /tmp/conmon-test-images
+          key: ${{ runner.os }}-cargo-test-files-${{ hashFiles('pkg/client/files_test.go') }}
       - run: .github/install-deps
       - name: Select Toolchain
         uses: actions-rs/toolchain@v1

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -27,11 +27,7 @@ import (
 	"github.com/opencontainers/runtime-tools/generate"
 )
 
-const (
-	maxRSSKB       = 3200
-	busyboxSource  = "https://busybox.net/downloads/binaries/1.31.0-i686-uclibc/busybox"
-	busyboxDestDir = "/tmp/conmon-test-images"
-)
+const maxRSSKB = 3200
 
 var (
 	busyboxDest = filepath.Join(busyboxDestDir, "busybox")
@@ -286,7 +282,8 @@ func downloadFile(url string, filepath string) error {
 	defer out.Close()
 
 	// Get the data
-	resp, err := http.Get(url)
+	client := http.Client{Timeout: time.Minute}
+	resp, err := client.Get(url)
 	if err != nil {
 		return err
 	}

--- a/pkg/client/files_test.go
+++ b/pkg/client/files_test.go
@@ -1,0 +1,6 @@
+package client_test
+
+const (
+	busyboxSource  = "https://busybox.net/downloads/binaries/1.31.0-i686-uclibc/busybox"
+	busyboxDestDir = "/tmp/conmon-test-images"
+)


### PR DESCRIPTION
We now cache the integration test files as well as increase the timeout
for their retrieval.