### PR TITLE
Add static release build artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,25 @@ jobs:
           components: rustfmt
       - run: cargo build
 
+  release-static:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-static-${{ hashFiles('**/Cargo.lock') }}
+      - run: make release-static
+      - uses: actions/upload-artifact@v2
+        with:
+          name: conmon
+          path: target/x86_64-unknown-linux-musl/release/conmon-server
+
   doc:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,29 @@
 MAKEFILE_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 RUNTIME_PATH ?= "/usr/bin/runc"
 PROTO_PATH ?= "conmon-rs/common/proto"
+BINARY := conmon-server
 
 default:
 	cargo build
 
 release:
 	cargo build --release
+
+.PHONY: release-static
+release-static:
+	mkdir -p ~/.cargo/git
+	podman run -it \
+		--pull always \
+		-v "$(shell pwd)":/volume \
+		-v ~/.cargo/registry:/root/.cargo/registry \
+		-v ~/.cargo/git:/root/.cargo/git \
+		clux/muslrust:stable \
+		bash -c "\
+			apt-get update && \
+			apt-get install -y capnproto && \
+			rustup component add rustfmt && \
+			make release && \
+			strip -s target/x86_64-unknown-linux-musl/release/$(BINARY)"
 
 lint:
 	cargo fmt
@@ -15,7 +32,7 @@ unit:
 	cargo test --bins --no-fail-fast
 
 integration: release # It needs to be release so we correctly test the RSS usage
-	CONMON_BINARY="$(MAKEFILE_PATH)target/release/conmon-server" RUNTIME_BINARY="$(RUNTIME_PATH)" go test -v pkg/client/*
+	CONMON_BINARY="$(MAKEFILE_PATH)target/release/$(BINARY)" RUNTIME_BINARY="$(RUNTIME_PATH)" go test -v pkg/client/*
 
 clean:
 	rm -rf target/
@@ -28,6 +45,5 @@ update-proto:
 		-ogo $(PROTO_PATH)/conmon.capnp
 	mv $(PROTO_PATH)/conmon.capnp.go internal/proto/
 	git checkout $(PROTO_PATH)/conmon.capnp
-
 
 .PHONY: lint clean unit integration update-proto


### PR DESCRIPTION
This allows us to re-use the pre-built binary in other projects, like CRI-O.
