### PR TITLE
Rename `conmon-server` to `conmon` (v3.0.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,11 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-static-${{ hashFiles('**/Cargo.lock') }}
       - run: make release-static
-      - run: target/x86_64-unknown-linux-musl/release/conmon-server -v
+      - run: target/x86_64-unknown-linux-musl/release/conmon -v
       - uses: actions/upload-artifact@v2
         with:
           name: conmon
-          path: target/x86_64-unknown-linux-musl/release/conmon-server
+          path: target/x86_64-unknown-linux-musl/release/conmon
 
   doc:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,31 +244,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "conmon-client"
-version = "0.1.0"
-dependencies = [
- "async-io",
- "async-net",
- "capnp",
- "capnp-rpc",
- "conmon-common",
- "futures",
- "log",
- "serde",
- "tokio",
-]
-
-[[package]]
-name = "conmon-common"
-version = "0.1.0"
-dependencies = [
- "capnp",
- "capnpc",
-]
-
-[[package]]
-name = "conmon-server"
-version = "0.1.0"
+name = "conmon"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "capnp",
@@ -293,6 +270,29 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "conmon-client"
+version = "0.1.0"
+dependencies = [
+ "async-io",
+ "async-net",
+ "capnp",
+ "capnp-rpc",
+ "conmon-common",
+ "futures",
+ "log",
+ "serde",
+ "tokio",
+]
+
+[[package]]
+name = "conmon-common"
+version = "0.1.0"
+dependencies = [
+ "capnp",
+ "capnpc",
 ]
 
 [[package]]
@@ -1099,7 +1099,7 @@ dependencies = [
  "atty",
  "colored",
  "log",
- "time 0.3.6",
+ "time 0.3.7",
  "winapi",
 ]
 
@@ -1255,9 +1255,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d54b9298e05179c335de2b9645d061255bcd5155f843b3e328d2cfe0a5b413"
+checksum = "004cbc98f30fa233c61a38bc77e96a9106e65c88f2d3bef182ae952027e5753d"
 dependencies = [
  "itoa",
  "libc",

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MAKEFILE_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 RUNTIME_PATH ?= "/usr/bin/runc"
 PROTO_PATH ?= "conmon-rs/common/proto"
-BINARY := conmon-server
+BINARY := conmon
 
 default:
 	cargo build

--- a/conmon-rs/server/Cargo.toml
+++ b/conmon-rs/server/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "conmon-server"
-version = "0.1.0"
+name = "conmon"
+version = "3.0.0-dev"
 edition = "2018"
 
 [[bin]]
-name = "conmon-server"
+name = "conmon"
 path = "src/main.rs"
 
 [dependencies]

--- a/conmon-rs/server/src/main.rs
+++ b/conmon-rs/server/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use conmon_server::Server;
+use conmon::Server;
 
 fn main() -> Result<()> {
     Server::new()

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -17,9 +17,7 @@ import (
 	"github.com/containers/conmon-rs/internal/proto"
 )
 
-const (
-	binaryName = "conmon-server"
-)
+const binaryName = "conmon"
 
 type ConmonClient struct {
 	conmonPID uint32


### PR DESCRIPTION
The proposal is that we use `conmon` for the server binary and bump the development version to v3.0.0.