### PR TITLE
Make `conmon --version` CRI-O compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "conmon"
-version = "3.0.0"
+version = "3.0.0-dev"
 dependencies = [
  "anyhow",
  "capnp",

--- a/conmon-rs/server/src/config.rs
+++ b/conmon-rs/server/src/config.rs
@@ -1,6 +1,6 @@
 //! Configuration related structures
 use anyhow::{bail, Result};
-use clap::{AppSettings, Parser};
+use clap::{crate_name, AppSettings, Parser};
 use getset::{CopyGetters, Getters, Setters};
 use log::LevelFilter;
 use serde::{Deserialize, Serialize};
@@ -161,7 +161,7 @@ impl Config {
 
     /// Show more verbose version information and exit the program.
     pub fn print_version(&self) {
-        println!("version: {}", build::PKG_VERSION);
+        println!("{} version: {}", crate_name!(), build::PKG_VERSION);
         println!(
             "tag: {}",
             if build::TAG.is_empty() {


### PR DESCRIPTION
CRI-O's conmon version parsing fails right now there:
https://github.com/cri-o/cri-o/blob/2e81aea6aa5d7a2fab42c07cfbe7a3f6299cea23/internal/config/conmonmgr/conmonmgr.go#L35-L37

To fix that, we now prepend the crate name to the version output.