### PR TITLE
Fix error handling paths

### DIFF
--- a/conmon-rs/server/src/child_reaper.rs
+++ b/conmon-rs/server/src/child_reaper.rs
@@ -60,9 +60,9 @@ impl ChildReaper {
             .await?;
 
         if let Some(console) = console {
-            let _ = console
+            console
                 .wait_connected()
-                .context("wait for console socket connection");
+                .context("wait for console socket connection")?;
         }
 
         let grandchild_pid = fs::read_to_string(pidfile)

--- a/conmon-rs/server/src/console.rs
+++ b/conmon-rs/server/src/console.rs
@@ -274,7 +274,7 @@ mod tests {
 
         // Write to the slave
         let mut file = unsafe { fs::File::from_raw_fd(res.slave) };
-        let _ = file.write(b"test").await?;
+        file.write_all(b"test").await?;
 
         Ok(())
     }

--- a/conmon-rs/server/src/lib.rs
+++ b/conmon-rs/server/src/lib.rs
@@ -3,7 +3,7 @@ use crate::{
     console::Console,
     init::{DefaultInit, Init},
 };
-use anyhow::{Context, Result};
+use anyhow::{format_err, Context, Result};
 use capnp_rpc::{rpc_twoparty_capnp::Side, twoparty, RpcSystem};
 use conmon_common::conmon_capnp::conmon;
 use futures::{AsyncReadExt, FutureExt};
@@ -167,7 +167,9 @@ impl Server {
             }
         };
 
-        let _ = shutdown_tx.send(());
+        shutdown_tx
+            .send(())
+            .map_err(|_| format_err!("unable to send shutdown message"))?;
 
         // TODO FIXME Ideally we would drop after socket file is removed,
         // but the removal is taking longer than 10 seconds, indicating someone

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -122,7 +122,7 @@ var _ = Describe("ConmonClient", func() {
 			if terminal {
 				testName += " with terminal"
 			}
-			It("should write exit file", func() {
+			It(testName, func() {
 				createRuntimeConfig(terminal)
 
 				exitPath := MustFileInTempDir(tmpDir, "exit")


### PR DESCRIPTION
Some errors can actually be returned or mapped by using the convenience
macro. We also fix a test name for the integration tests.
