### PR TITLE
Use cri-o bucket for busybox test binary

### DIFF
--- a/pkg/client/files_test.go
+++ b/pkg/client/files_test.go
@@ -1,6 +1,8 @@
 package client_test
 
 const (
-	busyboxSource  = "https://busybox.net/downloads/binaries/1.31.0-i686-uclibc/busybox"
+	// copied to our CRI-O bucket from:
+	// https://busybox.net/downloads/binaries/1.31.0-i686-uclibc/busybox
+	busyboxSource  = "https://storage.googleapis.com/cri-o/test-binaries/busybox"
 	busyboxDestDir = "/tmp/conmon-test-images"
 )


### PR DESCRIPTION
To avoid more flaky tests we now use our own Google Cloud bucket for the
test binary rather than the official sources which often timeout.
