### PR TITLE
client, server: add and use runtime dir instead of relying on temp files

### DIFF
--- a/conmon-rs/server/src/container_io.rs
+++ b/conmon-rs/server/src/container_io.rs
@@ -1,7 +1,7 @@
 use crate::{streams::Streams, terminal::Terminal};
 use anyhow::{Context, Result};
 use crossbeam_channel::Sender;
-use std::sync::mpsc::Receiver;
+use std::{path::Path, sync::mpsc::Receiver};
 
 /// A generic abstraction over various container input-output types
 pub enum ContainerIO {
@@ -23,9 +23,11 @@ impl From<Streams> for ContainerIO {
 
 impl ContainerIO {
     /// Create a new container IO instance.
-    pub fn new(terminal: bool) -> Result<Self> {
+    pub fn new(runtime_dir: &Path, terminal: bool) -> Result<Self> {
         Ok(if terminal {
-            Terminal::new().context("create new terminal")?.into()
+            Terminal::new(runtime_dir)
+                .context("create new terminal")?
+                .into()
         } else {
             Streams::new().context("create new streams")?.into()
         })

--- a/conmon-rs/server/src/rpc.rs
+++ b/conmon-rs/server/src/rpc.rs
@@ -101,6 +101,8 @@ impl conmon::Server for Server {
         let req = pry!(pry!(params.get()).get_request());
         let id = pry!(req.get_id()).to_string();
         let timeout = req.get_timeout_sec();
+        // TODO FIXME: add defer style removal--possibly with a macro or creating a special type
+        // that can be dropped?
         let pidfile = pry_err!(Terminal::temp_file_name(
             self.config().runtime_dir(),
             "exec_sync",

--- a/conmon-rs/server/src/rpc.rs
+++ b/conmon-rs/server/src/rpc.rs
@@ -57,7 +57,10 @@ impl conmon::Server for Server {
         let id = pry!(req.get_id()).to_string();
         debug!("Got a create container request for id {}", id);
 
-        let container_io = pry_err!(ContainerIO::new(req.get_terminal()));
+        let container_io = pry_err!(ContainerIO::new(
+            self.config().runtime_dir(),
+            req.get_terminal()
+        ));
         let bundle_path = PathBuf::from(pry!(req.get_bundle_path()));
         let pidfile = bundle_path.join("pidfile");
         debug!("PID file is {}", pidfile.display());
@@ -98,17 +101,23 @@ impl conmon::Server for Server {
         let req = pry!(pry!(params.get()).get_request());
         let id = pry!(req.get_id()).to_string();
         let timeout = req.get_timeout_sec();
-        let pidfile = pry_err!(Terminal::temp_file_name("exec_sync", "pid"));
+        let pidfile = pry_err!(Terminal::temp_file_name(
+            self.config().runtime_dir(),
+            "exec_sync",
+            "pid"
+        ));
 
         debug!(
             "Got exec sync container request for id {} with timeout {}",
             id, timeout,
         );
 
-        let container_io = pry_err!(ContainerIO::new(req.get_terminal()));
+        let container_io = pry_err!(ContainerIO::new(
+            self.config().runtime_dir(),
+            req.get_terminal()
+        ));
         let args = pry_err!(self.generate_exec_sync_args(&pidfile, &container_io, &params));
         let runtime = self.config().runtime().clone();
-
         let child_reaper = Arc::clone(self.reaper());
 
         // Verify the original container is still running

--- a/conmon-rs/server/src/server.rs
+++ b/conmon-rs/server/src/server.rs
@@ -117,7 +117,7 @@ impl Server {
     /// Spwans all required tokio tasks.
     async fn spawn_tasks(self) -> Result<()> {
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
-        let socket = self.config().socket().to_path_buf();
+        let socket = self.config().socket();
         tokio::spawn(Self::start_signal_handler(
             Arc::clone(self.reaper()),
             socket,

--- a/conmon-rs/server/src/server.rs
+++ b/conmon-rs/server/src/server.rs
@@ -66,10 +66,9 @@ impl Server {
         if !self.config().skip_fork() {
             match unsafe { fork()? } {
                 ForkResult::Parent { child, .. } => {
-                    if let Some(path) = &self.config().conmon_pidfile() {
-                        let child_str = format!("{}", child);
-                        File::create(path)?.write_all(child_str.as_bytes())?;
-                    }
+                    let child_str = format!("{}", child);
+                    File::create(self.config().conmon_pidfile())?
+                        .write_all(child_str.as_bytes())?;
                     unsafe { _exit(0) };
                 }
                 ForkResult::Child => (),

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -36,7 +36,7 @@ var (
 	busyboxDest = filepath.Join(busyboxDestDir, "busybox")
 	runtimePath = os.Getenv("RUNTIME_BINARY")
 	conmonPath  = os.Getenv("CONMON_BINARY")
-	maxRSSKB    = 220
+	maxRSSKB    = 230
 )
 
 // TestConmonClient runs the created specs


### PR DESCRIPTION
This way, we know a conmon-rs's files are cleaned up after its runtime dir is 