### PR TITLE
Move version back to v0.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,10 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-static-${{ hashFiles('**/Cargo.lock') }}
       - run: make release-static
-      - run: target/x86_64-unknown-linux-musl/release/conmon -v
+      - run: target/x86_64-unknown-linux-musl/release/conmonrs -v
       - uses: actions/upload-artifact@v2
         with:
-          name: conmon
+          name: conmonrs
           path: target/x86_64-unknown-linux-musl/release/conmonrs
 
   doc:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "conmon"
-version = "3.0.0-dev"
+version = "0.1.0-dev"
 dependencies = [
  "anyhow",
  "capnp",

--- a/conmon-rs/server/Cargo.toml
+++ b/conmon-rs/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conmon"
-version = "3.0.0-dev"
+version = "0.1.0-dev"
 edition = "2018"
 
 [[bin]]

--- a/conmon-rs/server/src/version.rs
+++ b/conmon-rs/server/src/version.rs
@@ -1,6 +1,5 @@
 //! Generic version information for conmon
 
-use clap::crate_name;
 use getset::CopyGetters;
 use shadow_rs::shadow;
 
@@ -40,7 +39,7 @@ impl Version {
 
     /// Print the version information to stdout.
     pub fn print(&self) {
-        println!("{} version {}", crate_name!(), build::PKG_VERSION);
+        println!("version: {}", build::PKG_VERSION);
         println!(
             "tag: {}",
             if build::TAG.is_empty() {


### PR DESCRIPTION
Since the binary name changed, we now can go back to an unreleased version.