### PR TITLE
change client name to be conmonrs-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,7 +275,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "conmon-client"
+name = "conmon-common"
+version = "0.1.0"
+dependencies = [
+ "capnp",
+ "capnpc",
+]
+
+[[package]]
+name = "conmonrs-cli"
 version = "0.1.0"
 dependencies = [
  "async-io",
@@ -287,14 +295,6 @@ dependencies = [
  "log",
  "serde",
  "tokio",
-]
-
-[[package]]
-name = "conmon-common"
-version = "0.1.0"
-dependencies = [
- "capnp",
- "capnpc",
 ]
 
 [[package]]

--- a/conmon-rs/client/Cargo.toml
+++ b/conmon-rs/client/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "conmon-client"
+name = "conmonrs-cli"
 version = "0.1.0"
 edition = "2018"
 


### PR DESCRIPTION
Changes the conmon client to be conmonrs-cli to be more consistent with the server name.

Signed-off-by: Ryan Phillips <ryan@trolocsis.com>