### PR TITLE
Use getset for `Child`

### DIFF
--- a/conmon-rs/server/src/child.rs
+++ b/conmon-rs/server/src/child.rs
@@ -1,10 +1,16 @@
+use getset::{CopyGetters, Getters};
 use std::path::PathBuf;
 
-#[derive(Debug)]
+#[derive(Debug, CopyGetters, Getters)]
 pub struct Child {
-    pub id: String,
-    pub pid: u32,
-    pub exit_paths: Vec<PathBuf>,
+    #[getset(get = "pub")]
+    id: String,
+
+    #[getset(get_copy = "pub")]
+    pid: u32,
+
+    #[getset(get = "pub")]
+    exit_paths: Vec<PathBuf>,
 }
 
 impl Child {

--- a/conmon-rs/server/src/child_reaper.rs
+++ b/conmon-rs/server/src/child_reaper.rs
@@ -85,9 +85,9 @@ impl ChildReaper {
 
         let (exit_tx, exit_rx) = reapable_grandchild.watch();
 
-        map.insert(child.id, reapable_grandchild);
+        map.insert(child.id().clone(), reapable_grandchild);
         let cleanup_grandchildren = locked_grandchildren.clone();
-        let pid = child.pid;
+        let pid = child.pid();
 
         task::spawn(async move {
             exit_tx.subscribe().recv().await?;
@@ -140,14 +140,14 @@ impl ChildReaper {
 #[derive(Default, Debug, Clone)]
 pub struct ReapableChild {
     pub exit_paths: Vec<PathBuf>,
-    pub pid: u32,
+    pid: u32,
 }
 
 impl ReapableChild {
     pub fn from_child(child: &Child) -> Self {
         Self {
-            pid: child.pid,
-            exit_paths: child.exit_paths.clone(),
+            pid: child.pid(),
+            exit_paths: child.exit_paths().clone(),
         }
     }
 


### PR DESCRIPTION
This makes required clones more visible, for example for the map
insertion.
