### PR TITLE
add integration-static target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,4 +171,4 @@ jobs:
           key: ${{ runner.os }}-cargo-test-files-${{ hashFiles('pkg/client/files_test.go') }}
       - run: .github/install-deps
       - name: Integration tests
-        run: RUNTIME_PATH="/usr/sbin/runc" make integration
+        run: RUNTIME_PATH="/usr/sbin/runc" make integration-static

--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,17 @@ lint:
 unit:
 	cargo test --bins --no-fail-fast
 
-integration: release-static # It needs to be release so we correctly test the RSS usage
+integration: release # It needs to be release so we correctly test the RSS usage
+	export CONMON_BINARY="$(MAKEFILE_PATH)target/release/$(BINARY)" && \
+	export RUNTIME_BINARY="$(RUNTIME_PATH)" && \
+	export MAX_RSS_KB=3400 && \
+	go test pkg/client/* -v -ginkgo.v
+
+integration-static: release-static # It needs to be release so we correctly test the RSS usage
 	export CONMON_BINARY="$(MAKEFILE_PATH)target/x86_64-unknown-linux-musl/release/$(BINARY)" && \
 	export RUNTIME_BINARY="$(RUNTIME_PATH)" && \
 	go test pkg/client/* -v -ginkgo.v
+
 
 clean:
 	rm -rf target/

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 const (
-	maxRSSKB         = 220
 	timeoutUnlimited = 0
 )
 
@@ -37,10 +36,18 @@ var (
 	busyboxDest = filepath.Join(busyboxDestDir, "busybox")
 	runtimePath = os.Getenv("RUNTIME_BINARY")
 	conmonPath  = os.Getenv("CONMON_BINARY")
+	maxRSSKB    = 220
 )
 
 // TestConmonClient runs the created specs
 func TestConmonClient(t *testing.T) {
+	if rssStr := os.Getenv("MAX_RSS_KB"); rssStr != "" {
+		rssInt, err := strconv.Atoi(rssStr)
+		if err != nil {
+			t.Error(err)
+		}
+		maxRSSKB = rssInt
+	}
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "ConmonClient")
 }


### PR DESCRIPTION
so users are able to run the integration tests without building statically

Signed-off-by: Peter Hunt <pehunt@redhat.com>