### PR TITLE
Explicitly use the local thread for grandchildren tasks

### DIFF
--- a/conmon-rs/server/src/child_reaper.rs
+++ b/conmon-rs/server/src/child_reaper.rs
@@ -102,7 +102,7 @@ impl ChildReaper {
         let cleanup_grandchildren = locked_grandchildren.clone();
         let pid = child.pid();
 
-        task::spawn(async move {
+        task::spawn_local(async move {
             exit_tx.subscribe().recv().await?;
             if let Some(stop_tx) = stop_tx {
                 stop_tx.send(()).context("send message to stop channel")?;


### PR DESCRIPTION
Using task::spawn may cause a thread leak when running from other tasks
in a single threaded tokio environment (like we have it). We now use
spawn_local to explicitly use the local thread.
