### PR TITLE
client, server: add support for very long server runtime dir paths

### DIFF
--- a/conmon-rs/server/src/config.rs
+++ b/conmon-rs/server/src/config.rs
@@ -146,9 +146,6 @@ impl Config {
         if self.socket().exists() {
             fs::remove_file(self.socket())?;
         }
-        if let Some(parent) = self.socket().parent() {
-            fs::create_dir_all(parent)?;
-        }
 
         Ok(())
     }

--- a/conmon-rs/server/src/container_io.rs
+++ b/conmon-rs/server/src/container_io.rs
@@ -1,7 +1,7 @@
 use crate::{streams::Streams, terminal::Terminal};
 use anyhow::{Context, Result};
 use crossbeam_channel::Sender;
-use std::{path::Path, sync::mpsc::Receiver};
+use std::sync::mpsc::Receiver;
 
 /// A generic abstraction over various container input-output types
 pub enum ContainerIO {
@@ -23,11 +23,9 @@ impl From<Streams> for ContainerIO {
 
 impl ContainerIO {
     /// Create a new container IO instance.
-    pub fn new(runtime_dir: &Path, terminal: bool) -> Result<Self> {
+    pub fn new(terminal: bool) -> Result<Self> {
         Ok(if terminal {
-            Terminal::new(runtime_dir)
-                .context("create new terminal")?
-                .into()
+            Terminal::new().context("create new terminal")?.into()
         } else {
             Streams::new().context("create new streams")?.into()
         })

--- a/conmon-rs/server/src/lib.rs
+++ b/conmon-rs/server/src/lib.rs
@@ -8,6 +8,7 @@ mod config;
 mod container_io;
 mod cri_logger;
 mod init;
+mod listener;
 mod rpc;
 mod server;
 mod stream;

--- a/conmon-rs/server/src/listener.rs
+++ b/conmon-rs/server/src/listener.rs
@@ -1,0 +1,32 @@
+use anyhow::{bail, Context, Result};
+use std::{
+    fs::File,
+    os::unix::io::AsRawFd,
+    path::{Path, PathBuf},
+};
+use tokio::net::UnixListener;
+
+pub fn bind_long_path(path: &Path) -> Result<UnixListener> {
+    let parent = match path.parent() {
+        Some(p) => p,
+        None => bail!(
+            "Tried to specify / as socket to bind to: {}",
+            path.display()
+        ),
+    };
+    let name = match path.file_name() {
+        Some(n) => n,
+        None => bail!(
+            "Tried to specify .. as socket to bind to: {}",
+            path.display()
+        ),
+    };
+
+    let parent = File::open(parent)?;
+    let fd = parent.as_raw_fd();
+    let socket_path = PathBuf::from("/proc/self/fd")
+        .join(fd.to_string())
+        .join(name);
+
+    UnixListener::bind(&socket_path).context("bind server socket")
+}

--- a/conmon-rs/server/src/rpc.rs
+++ b/conmon-rs/server/src/rpc.rs
@@ -57,10 +57,7 @@ impl conmon::Server for Server {
         let id = pry!(req.get_id()).to_string();
         debug!("Got a create container request for id {}", id);
 
-        let container_io = pry_err!(ContainerIO::new(
-            self.config().runtime_dir(),
-            req.get_terminal()
-        ));
+        let container_io = pry_err!(ContainerIO::new(req.get_terminal()));
         let bundle_path = PathBuf::from(pry!(req.get_bundle_path()));
         let pidfile = bundle_path.join("pidfile");
         debug!("PID file is {}", pidfile.display());
@@ -104,7 +101,7 @@ impl conmon::Server for Server {
         // TODO FIXME: add defer style removal--possibly with a macro or creating a special type
         // that can be dropped?
         let pidfile = pry_err!(Terminal::temp_file_name(
-            self.config().runtime_dir(),
+            Some(self.config().runtime_dir()),
             "exec_sync",
             "pid"
         ));
@@ -114,10 +111,7 @@ impl conmon::Server for Server {
             id, timeout,
         );
 
-        let container_io = pry_err!(ContainerIO::new(
-            self.config().runtime_dir(),
-            req.get_terminal()
-        ));
+        let container_io = pry_err!(ContainerIO::new(req.get_terminal()));
         let args = pry_err!(self.generate_exec_sync_args(&pidfile, &container_io, &params));
         let runtime = self.config().runtime().clone();
         let child_reaper = Arc::clone(self.reaper());

--- a/conmon-rs/server/src/server.rs
+++ b/conmon-rs/server/src/server.rs
@@ -20,7 +20,6 @@ use nix::{
 use std::{fs::File, io::Write, path::Path, process, sync::Arc};
 use tokio::{
     fs,
-    net::UnixListener,
     runtime::{Builder, Handle},
     signal::unix::{signal, SignalKind},
     sync::oneshot,
@@ -168,7 +167,7 @@ impl Server {
     }
 
     async fn start_backend(self, mut shutdown_rx: oneshot::Receiver<()>) -> Result<()> {
-        let listener = UnixListener::bind(&self.config().socket()).context("bind server socket")?;
+        let listener = crate::listener::bind_long_path(&self.config().socket())?;
         let client: conmon::Client = capnp_rpc::new_client(self);
 
         loop {

--- a/conmon-rs/server/src/terminal.rs
+++ b/conmon-rs/server/src/terminal.rs
@@ -21,7 +21,7 @@ use tempfile::Builder;
 use tokio::{
     fs,
     io::{AsyncWriteExt, Interest},
-    net::{UnixListener, UnixStream},
+    net::UnixStream,
     task,
 };
 
@@ -104,7 +104,7 @@ impl Terminal {
     async fn listen(config: Config) -> Result<()> {
         let path = config.path();
         debug!("Listening terminal socket on {}", path.display());
-        let listener = UnixListener::bind(path)?;
+        let listener = crate::listener::bind_long_path(path)?;
 
         // Update the permissions
         let mut perms = fs::metadata(path).await?.permissions();


### PR DESCRIPTION
The runtime dir path will likely be the infra container's runDir, and thus something with a container UUID in it. Thus, it would be too long to hold the conmon.sock and work with the unix socket length. Work around this in the same way it was worked around in conmon (shout out to @giuseppe for coming up with the fix), where we use the `/proc/self/fd` entry of the parent directory of the target socket, and reference that when Dialing/Listening.

This also partially reverts https://github.com/containers/conmon-rs/pull/284, because for now runc doesn't support this functionality, so the process of receiving the console fd fails