### PR TITLE
Use `Context` for `Option` type unwrapping

### DIFF
--- a/conmon-rs/server/src/listener.rs
+++ b/conmon-rs/server/src/listener.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use std::{
     fs::File,
     os::unix::io::AsRawFd,
@@ -7,20 +7,14 @@ use std::{
 use tokio::net::UnixListener;
 
 pub fn bind_long_path(path: &Path) -> Result<UnixListener> {
-    let parent = match path.parent() {
-        Some(p) => p,
-        None => bail!(
-            "Tried to specify / as socket to bind to: {}",
-            path.display()
-        ),
-    };
-    let name = match path.file_name() {
-        Some(n) => n,
-        None => bail!(
-            "Tried to specify .. as socket to bind to: {}",
-            path.display()
-        ),
-    };
+    let parent = path.parent().context(format!(
+        "tried to specify / as socket to bind to: {}",
+        path.display()
+    ))?;
+    let name = path.file_name().context(format!(
+        "tried to specify '..' as socket to bind to: {}",
+        path.display(),
+    ))?;
 
     let parent = File::open(parent)?;
     let fd = parent.as_raw_fd();


### PR DESCRIPTION
Just a small follow-up on: https://github.com/containers/conmon-rs/pull/310
