### PR TITLE
Use async read/write for attach

### DIFF
--- a/conmon-rs/server/src/attach.rs
+++ b/conmon-rs/server/src/attach.rs
@@ -1,22 +1,42 @@
 use anyhow::{bail, Context, Result};
+use getset::Getters;
 use log::{debug, error};
 use nix::sys::socket::{
     bind, listen, socket, AddressFamily, SockAddr, SockFlag, SockType, UnixAddr,
 };
 use std::{
-    io::{BufReader, BufWriter, Read, Write},
     os::unix::{
         fs::PermissionsExt,
         io::{FromRawFd, RawFd},
-        net::{UnixListener, UnixStream},
+        net,
     },
     path::Path,
-    thread,
+};
+use tokio::{
+    io::{ErrorKind, Interest},
+    net::{UnixListener, UnixStream},
+    select,
+    sync::broadcast::{self, Receiver, Sender},
+    task,
 };
 
-#[derive(Clone, Debug)]
+/// The size of an attach packet.
+pub const ATTACH_PACKET_BUF_SIZE: usize = 8192;
+
+// TODO: remove this when being used
+#[allow(dead_code)]
+#[derive(Clone, Debug, Getters)]
 /// Attach handles the attach socket IO of a container.
-pub struct Attach;
+pub struct Attach {
+    #[getset(get = "pub")]
+    stdin: Sender<Vec<u8>>,
+
+    #[getset(get = "pub")]
+    stdout: Sender<Vec<u8>>,
+
+    #[getset(get = "pub")]
+    stderr: Sender<Vec<u8>>,
+}
 
 impl Attach {
     /// Create a a new attach instance.
@@ -46,42 +66,132 @@ impl Attach {
         permissions.set_mode(0o700);
 
         listen(fd, 10).context("listen on socket fd")?;
-        thread::spawn(move || Self::start_listening(fd));
 
-        Ok(Self {})
+        const BROADCAST_CAPACITY: usize = 64;
+
+        let (stdin_tx, _) = broadcast::channel(BROADCAST_CAPACITY);
+        let (stdout_tx, _) = broadcast::channel(BROADCAST_CAPACITY);
+        let (stderr_tx, _) = broadcast::channel(BROADCAST_CAPACITY);
+
+        let (stdin_clone, stdout_clone, stderr_clone) =
+            (stdin_tx.clone(), stdout_tx.clone(), stderr_tx.clone());
+
+        task::spawn(async move {
+            Self::start_listening(fd, stdin_clone, stdout_clone, stderr_clone).await
+        });
+
+        Ok(Self {
+            stdin: stdin_tx,
+            stdout: stdout_tx,
+            stderr: stderr_tx,
+        })
     }
 
-    fn start_listening(fd: RawFd) -> Result<()> {
+    async fn start_listening(
+        fd: RawFd,
+        stdin: Sender<Vec<u8>>,
+        stdout: Sender<Vec<u8>>,
+        stderr: Sender<Vec<u8>>,
+    ) -> Result<()> {
         debug!("Start listening on attach socket");
-        let listener = unsafe { UnixListener::from_raw_fd(fd) };
-        for stream in listener.incoming() {
-            thread::spawn(|| Self::handle_client(stream?));
+        let listener = UnixListener::from_std(unsafe { net::UnixListener::from_raw_fd(fd) })?;
+        loop {
+            match listener.accept().await {
+                Ok((stream, _)) => {
+                    let stdin_tx = stdin.clone();
+                    let stdout_rx = stdout.subscribe();
+                    let stderr_rx = stderr.subscribe();
+                    task::spawn(async move {
+                        if let Err(e) =
+                            Self::handle_client(stream, stdin_tx, stdout_rx, stderr_rx).await
+                        {
+                            error!("Unable to handle attach client: {:#}", e)
+                        }
+                    });
+
+                    // TODO: remove me when integrated
+                    let stdout_clone = stdout.clone();
+                    let stderr_clone = stderr.clone();
+                    task::spawn(async move {
+                        stdout_clone.send("Hello stdout!".into()).unwrap();
+                        stderr_clone.send("Hello stderr!".into()).unwrap();
+                    });
+                }
+                Err(e) => error!("Unable to accept attach stream: {}", e),
+            }
         }
-        Ok(())
     }
 
-    fn handle_client(stream: UnixStream) -> Result<()> {
+    async fn handle_client(
+        stream: UnixStream,
+        _stdin: Sender<Vec<u8>>,
+        mut stdout: Receiver<Vec<u8>>,
+        mut stderr: Receiver<Vec<u8>>,
+    ) -> Result<()> {
         debug!("Got new attach stream connection");
 
-        let mut reader = BufReader::new(&stream);
-        let mut writer = BufWriter::new(&stream);
-
-        const BUF_SIZE: usize = 8192;
-        let mut buf = vec![0; BUF_SIZE];
-
-        // TODO: implement me
-        buf[0] = 2;
-        writer.write_all(&buf)?;
-        buf[0] = 3;
-        writer.write_all(&buf)?;
+        // The first byte indicates that we either handle stdout or stderr.
+        // This behavior is inherited from the original conmon.
+        enum Pipe {
+            Stdout = 2,
+            Stderr = 3,
+        }
 
         loop {
-            match reader.read(&mut buf) {
-                Ok(n) if n > 0 => {
-                    debug!("Read {} bytes", n);
+            let ready = stream
+                .ready(Interest::READABLE | Interest::WRITABLE)
+                .await?;
+
+            if ready.is_readable() {
+                let mut buf = vec![0; ATTACH_PACKET_BUF_SIZE];
+                match stream.try_read(&mut buf) {
+                    Ok(n) if n > 0 => {
+                        if let Some(first_zero_idx) = buf.iter().position(|&x| x == 0) {
+                            buf.resize(first_zero_idx, 0);
+                        }
+                        debug!("Read {} stdin bytes", buf.len());
+                        // TODO: send stdin when integrated
+                        // stdin.send(buf)?;
+                    }
+                    Err(ref e) if e.kind() == ErrorKind::WouldBlock => continue,
+                    Err(e) => return Err(e.into()),
+                    _ => {}
                 }
-                Err(e) => error!("Unable to read from file descriptor: {}", e),
-                _ => {}
+            }
+
+            if ready.is_writable() {
+                let packets = select! {
+                    res = stdout.recv() => {
+                        res?.chunks(ATTACH_PACKET_BUF_SIZE - 1)
+                            .map(|x| {
+                                let mut y = x.to_vec();
+                                y.insert(0, Pipe::Stdout as u8);
+                                y.resize(ATTACH_PACKET_BUF_SIZE, 0);
+                                y
+                            })
+                            .collect::<Vec<_>>()
+                    },
+                    res = stderr.recv() => {
+                        res?.chunks(ATTACH_PACKET_BUF_SIZE - 1)
+                            .map(|x| {
+                                let mut y = x.to_vec();
+                                y.insert(0, Pipe::Stderr as u8);
+                                y.resize(ATTACH_PACKET_BUF_SIZE, 0);
+                                y
+                            })
+                            .collect::<Vec<_>>()
+                    },
+                };
+
+                for packet in packets {
+                    match stream.try_write(&packet) {
+                        Ok(_) => {
+                            debug!("Wrote stdout/stderr packet");
+                        }
+                        Err(ref e) if e.kind() == ErrorKind::WouldBlock => continue,
+                        Err(e) => return Err(e.into()),
+                    }
+                }
             }
         }
     }

--- a/conmon-rs/server/src/child_reaper.rs
+++ b/conmon-rs/server/src/child_reaper.rs
@@ -1,5 +1,5 @@
 //! Child process reaping and management.
-use crate::{attach::Attach, child::Child, container_io::ContainerIO, cri_logger::SharedCriLogger};
+use crate::{child::Child, container_io::ContainerIO, cri_logger::SharedCriLogger};
 use anyhow::{anyhow, format_err, Context, Result};
 use getset::{CopyGetters, Getters, Setters};
 use libc::pid_t;
@@ -163,9 +163,6 @@ pub struct ReapableChild {
     #[getset(get_copy)]
     pid: u32,
 
-    #[getset(set = "pub")]
-    attach: Option<Attach>,
-
     #[getset(get = "pub")]
     cri_logger: SharedCriLogger,
 }
@@ -175,7 +172,6 @@ impl ReapableChild {
         Self {
             pid: child.pid(),
             exit_paths: child.exit_paths().clone(),
-            attach: None,
             cri_logger: child.cri_logger().clone(),
         }
     }

--- a/conmon-rs/server/src/rpc.rs
+++ b/conmon-rs/server/src/rpc.rs
@@ -214,10 +214,8 @@ impl conmon::Server for Server {
         }
 
         let socket_path = Path::new(pry!(req.get_socket_path()));
-        let attach = pry_err!(Attach::new(socket_path).context("create attach endpoint"));
-
-        let mut child = pry_err!(self.reaper().get(container_id));
-        child.set_attach(attach.into());
+        let _attach = pry_err!(Attach::new(socket_path).context("create attach endpoint"));
+        let mut _child = pry_err!(self.reaper().get(container_id));
 
         Promise::ok(())
     }


### PR DESCRIPTION
We now use async IO for attach as well as setting up the channels to read and write from them.

Refers to https://github.com/containers/conmon-rs/issues/287