### PR TITLE
Cleanup shared container log creation

### DIFF
--- a/conmon-rs/server/src/container_log.rs
+++ b/conmon-rs/server/src/container_log.rs
@@ -28,10 +28,12 @@ pub enum Pipe {
 }
 
 impl ContainerLog {
-    pub fn new() -> Result<SharedContainerLog> {
-        let drivers = vec![];
-        Ok(Arc::new(RwLock::new(Self { drivers })))
+    /// Create a new default SharedContainerLog.
+    pub fn new() -> SharedContainerLog {
+        Arc::new(RwLock::new(Self::default()))
     }
+
+    /// Create a new SharedContainerLog from an capnp owned reader.
     pub fn from(reader: Reader<Owned>) -> Result<SharedContainerLog> {
         let drivers = reader
             .iter()

--- a/conmon-rs/server/src/rpc.rs
+++ b/conmon-rs/server/src/rpc.rs
@@ -119,7 +119,7 @@ impl conmon::Server for Server {
         let runtime = self.config().runtime().clone();
         let child_reaper = self.reaper().clone();
 
-        let logger = pry_err!(ContainerLog::new());
+        let logger = ContainerLog::new();
         let mut container_io = pry_err!(ContainerIO::new(req.get_terminal(), logger.clone()));
         let args = pry_err!(self.generate_exec_sync_args(&pidfile, &container_io, &params));
 

--- a/conmon-rs/server/src/terminal.rs
+++ b/conmon-rs/server/src/terminal.rs
@@ -259,12 +259,11 @@ mod tests {
     use crate::container_log::ContainerLog;
     use nix::pty;
     use sendfd::SendWithFd;
-    use std::{os::unix::io::FromRawFd, sync::Arc};
-    use tokio::sync::RwLock;
+    use std::os::unix::io::FromRawFd;
 
     #[tokio::test]
     async fn new_success() -> Result<()> {
-        let logger = Arc::new(RwLock::new(ContainerLog::default()));
+        let logger = ContainerLog::new();
 
         let sut = Terminal::new(logger)?;
         assert!(sut.path().exists());


### PR DESCRIPTION
We can use the `Self::default()` for creating the instance since we
derive it. Beside that we can re-use that function in the unit tests and
make it non-fallible.
