### PR TITLE
streams/terminal: unify read loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ unit:
 integration: release # It needs to be release so we correctly test the RSS usage
 	export CONMON_BINARY="$(MAKEFILE_PATH)target/release/$(BINARY)" && \
 	export RUNTIME_BINARY="$(RUNTIME_PATH)" && \
-	export MAX_RSS_KB=3400 && \
+	export MAX_RSS_KB=3900 && \
 	go test pkg/client/* -v -ginkgo.v
 
 integration-static: release-static # It needs to be release so we correctly test the RSS usage

--- a/conmon-rs/server/src/child_reaper.rs
+++ b/conmon-rs/server/src/child_reaper.rs
@@ -104,11 +104,7 @@ impl ChildReaper {
         Ok(grandchild_pid)
     }
 
-    pub fn watch_grandchild(
-        &self,
-        child: Child,
-        stop_tx: Option<Sender<()>>,
-    ) -> Result<Receiver<i32>> {
+    pub fn watch_grandchild(&self, child: Child) -> Result<Receiver<i32>> {
         let locked_grandchildren = Arc::clone(&self.grandchildren);
         let mut map = lock!(locked_grandchildren);
         let reapable_grandchild = ReapableChild::from_child(&child);
@@ -121,9 +117,6 @@ impl ChildReaper {
 
         task::spawn(async move {
             exit_tx.subscribe().recv().await?;
-            if let Some(stop_tx) = stop_tx {
-                stop_tx.send(()).context("send message to stop channel")?;
-            }
             Self::forget_grandchild(&cleanup_grandchildren, pid)
         });
         Ok(exit_rx)

--- a/conmon-rs/server/src/child_reaper.rs
+++ b/conmon-rs/server/src/child_reaper.rs
@@ -94,11 +94,12 @@ impl ChildReaper {
             return Err(anyhow!(code_str));
         }
 
+        let pidfile = pidfile.as_path();
         let grandchild_pid = fs::read_to_string(pidfile)
             .await
-            .context("grandchild pid read error")?
+            .context(format!("grandchild pid read error {}", pidfile.display()))?
             .parse::<u32>()
-            .context("grandchild pid parse error")?;
+            .context(format!("grandchild pid parse error {}", pidfile.display()))?;
 
         Ok(grandchild_pid)
     }

--- a/conmon-rs/server/src/container_io.rs
+++ b/conmon-rs/server/src/container_io.rs
@@ -1,6 +1,6 @@
 use crate::{container_log::SharedContainerLog, streams::Streams, terminal::Terminal};
 use anyhow::{Context, Result};
-use tokio::sync::{broadcast::Sender, mpsc::UnboundedReceiver};
+use tokio::sync::mpsc::UnboundedReceiver;
 
 /// A generic abstraction over various container input-output types
 pub enum ContainerIO {
@@ -35,14 +35,6 @@ impl ContainerIO {
         match self {
             ContainerIO::Terminal(t) => t.message_rx_mut(),
             ContainerIO::Streams(s) => s.message_rx_mut(),
-        }
-    }
-
-    /// Returns the stop channel if available.
-    pub fn stop_tx(&self) -> Option<Sender<()>> {
-        match self {
-            ContainerIO::Terminal(_) => None,
-            ContainerIO::Streams(i) => i.stop_tx().clone().into(),
         }
     }
 }

--- a/conmon-rs/server/src/container_io.rs
+++ b/conmon-rs/server/src/container_io.rs
@@ -1,6 +1,6 @@
 use crate::{container_log::SharedContainerLog, streams::Streams, terminal::Terminal};
 use anyhow::{Context, Result};
-use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::{sync::mpsc::UnboundedReceiver, time};
 
 /// A generic abstraction over various container input-output types
 pub enum ContainerIO {
@@ -30,12 +30,58 @@ impl ContainerIO {
         })
     }
 
-    /// Return the message receiver for the underlying type.
-    pub fn receiver(&mut self) -> &mut UnboundedReceiver<Message> {
+    pub async fn read_all_with_timeout(
+        &mut self,
+        time_to_timeout: Option<time::Instant>,
+    ) -> (Vec<u8>, Vec<u8>, bool) {
         match self {
-            ContainerIO::Terminal(t) => t.message_rx_mut(),
-            ContainerIO::Streams(s) => s.message_rx_mut(),
+            ContainerIO::Terminal(t) => {
+                let (stdout, timed_out) =
+                    Self::read_stream_with_timeout(time_to_timeout, t.message_rx_mut()).await;
+                (stdout, vec![], timed_out)
+            }
+            ContainerIO::Streams(s) => {
+                let stdout_rx = &mut s.message_rx_stdout;
+                let stderr_rx = &mut s.message_rx_stderr;
+                let (stdout, stderr) = tokio::join!(
+                    Self::read_stream_with_timeout(time_to_timeout, stdout_rx),
+                    Self::read_stream_with_timeout(time_to_timeout, stderr_rx),
+                );
+                let timed_out = stdout.1 || stderr.1;
+                (stdout.0, stderr.0, timed_out)
+            }
         }
+    }
+
+    async fn read_stream_with_timeout(
+        time_to_timeout: Option<time::Instant>,
+        receiver: &mut UnboundedReceiver<Message>,
+    ) -> (Vec<u8>, bool) {
+        let mut stdio = vec![];
+        let mut timed_out = false;
+        loop {
+            let msg = if let Some(time_to_timeout) = time_to_timeout {
+                match time::timeout_at(time_to_timeout, receiver.recv()).await {
+                    Ok(Some(msg)) => msg,
+                    Err(_) => {
+                        timed_out = true;
+                        Message::Done
+                    }
+                    Ok(None) => unreachable!(),
+                }
+            } else {
+                match receiver.recv().await {
+                    Some(msg) => msg,
+                    None => Message::Done,
+                }
+            };
+
+            match msg {
+                Message::Data(s) => stdio.extend(s),
+                Message::Done => break,
+            }
+        }
+        (stdio, timed_out)
     }
 }
 

--- a/conmon-rs/server/src/rpc.rs
+++ b/conmon-rs/server/src/rpc.rs
@@ -84,8 +84,7 @@ impl conmon::Server for Server {
 
             // register grandchild with server
             let child = Child::new(id, grandchild_pid, exit_paths, container_log);
-            let stop_tx = container_io.stop_tx();
-            capnp_err!(child_reaper.watch_grandchild(child, stop_tx))?;
+            capnp_err!(child_reaper.watch_grandchild(child))?;
 
             results
                 .get()
@@ -135,8 +134,7 @@ impl conmon::Server for Server {
 
                     let time_to_timeout = time::Instant::now() + Duration::from_secs(timeout);
 
-                    let stop_tx = container_io.stop_tx();
-                    let mut exit_rx = capnp_err!(child_reaper.watch_grandchild(child, stop_tx))?;
+                    let mut exit_rx = capnp_err!(child_reaper.watch_grandchild(child))?;
 
                     let mut stdio = vec![];
                     let mut timed_out = false;

--- a/conmon-rs/server/src/server.rs
+++ b/conmon-rs/server/src/server.rs
@@ -79,7 +79,6 @@ impl Server {
             .map_err(errno::from_i32)
             .context("set child subreaper")?;
 
-        // Use the single threaded runtime to save rss memory.
         let rt = Builder::new_multi_thread()
             .enable_io()
             .enable_time()

--- a/conmon-rs/server/src/streams.rs
+++ b/conmon-rs/server/src/streams.rs
@@ -4,16 +4,16 @@ use crate::{
     container_io::Message,
     container_log::{Pipe, SharedContainerLog},
 };
-use anyhow::{format_err, Context, Result};
+use anyhow::{Context, Result};
 use getset::{Getters, MutGetters};
-use log::{debug, error, trace};
+use log::{debug, error};
+use nix::errno::Errno;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use tokio::{
     fs::File,
     io::{AsyncReadExt, BufReader},
     process::{ChildStderr, ChildStdout},
-    select,
-    sync::{broadcast, mpsc, oneshot},
+    sync::mpsc,
     task,
 };
 
@@ -28,12 +28,6 @@ pub struct Streams {
 
     #[getset(get = "pub")]
     message_tx: mpsc::UnboundedSender<Message>,
-
-    #[getset(get = "pub")]
-    stop_tx: broadcast::Sender<()>,
-
-    #[getset(get = "pub")]
-    stop_rx: broadcast::Receiver<()>,
 }
 
 impl Streams {
@@ -42,14 +36,11 @@ impl Streams {
         debug!("Creating new IO streams");
 
         let (message_tx, message_rx) = mpsc::unbounded_channel();
-        let (stop_tx, stop_rx) = broadcast::channel(1);
 
         Ok(Self {
             logger,
             message_rx,
             message_tx,
-            stop_tx,
-            stop_rx,
         })
     }
 
@@ -57,105 +48,78 @@ impl Streams {
         debug!("Start reading from IO streams");
         let logger = self.logger().clone();
         let message_tx = self.message_tx().clone();
-        let stop_rx = self.stop_tx().subscribe();
 
         if let Some(stdout) = stdout {
             task::spawn(async move {
-                Self::read_loop_single_stream(
-                    logger,
-                    Pipe::StdOut,
-                    message_tx,
-                    stop_rx,
-                    stdout.as_raw_fd(),
-                )
-                .await
+                Self::read_loop(stdout.as_raw_fd(), Pipe::StdOut, logger, message_tx).await
             });
         }
 
         let logger = self.logger().clone();
         let message_tx = self.message_tx().clone();
-        let stop_rx = self.stop_tx().subscribe();
         if let Some(stderr) = stderr {
             task::spawn(async move {
-                Self::read_loop_single_stream(
-                    logger,
-                    Pipe::StdErr,
-                    message_tx,
-                    stop_rx,
-                    stderr.as_raw_fd(),
-                )
-                .await
+                Self::read_loop(stderr.as_raw_fd(), Pipe::StdErr, logger, message_tx).await
             });
         }
     }
 
-    async fn read_loop_single_stream(
-        logger: SharedContainerLog,
-        pipe: Pipe,
-        message_tx: mpsc::UnboundedSender<Message>,
-        mut stop_rx: broadcast::Receiver<()>,
+    pub async fn read_loop(
         fd: RawFd,
-    ) -> Result<()> {
-        trace!("Start reading from single fd: {:?}", fd);
-
-        let message_tx_clone = message_tx.clone();
-        let (thread_shutdown_tx, thread_shutdown_rx) = oneshot::channel();
-        task::spawn(async move {
-            Self::run_buffer_loop(logger, pipe, message_tx_clone, fd, thread_shutdown_rx).await
-        });
-
-        stop_rx
-            .recv()
-            .await
-            .context("unable to wait for stop channel")?;
-        debug!("Received IO stream stop signal");
-        thread_shutdown_tx
-            .send(())
-            .map_err(|_| format_err!("unable to send thread shutdown message"))?;
-        message_tx.send(Message::Done).context("send done message")
-    }
-
-    async fn run_buffer_loop(
-        logger: SharedContainerLog,
         pipe: Pipe,
+        logger: SharedContainerLog,
         message_tx: mpsc::UnboundedSender<Message>,
-        fd: RawFd,
-        mut thread_shutdown_rx: oneshot::Receiver<()>,
     ) -> Result<()> {
         let stream = unsafe { File::from_raw_fd(fd) };
-        let mut reader = BufReader::with_capacity(1024, stream);
+        let mut reader = BufReader::new(stream);
         let mut buf = vec![0; 1024];
         loop {
-            select! {
-                res = reader.read(&mut buf) => match res {
-                    Ok(n) if n > 0 => {
-                        debug!("Read {} bytes", n);
-                        let data = &buf[..n];
+            match reader.read(&mut buf).await {
+                Ok(n) if n > 0 => {
+                    debug!("Read {} bytes", n);
+                    let data = &buf[..n];
 
-                        let mut locked_logger = logger.write().await;
-                        locked_logger
-                            .write(pipe, data)
-                            .await
-                            .context("write to log file")?;
+                    let mut locked_logger = logger.write().await;
+                    locked_logger
+                        .write(pipe, data)
+                        .await
+                        .context("write to log file")?;
 
-                        if let Err(e) = message_tx.send(Message::Data(data.into())) {
-                            debug!("Unable to send data through message channel: {}", e);
-                        }
-                    }
-                    Err(e) => {
-                        if e.kind() == std::io::ErrorKind::WouldBlock {
-                            continue;
-                        }
-                        error!("Unable to read from io fd: {}", e);
-                    }
-                    _ => {}
-                },
-                _ = &mut thread_shutdown_rx => {
-                    debug!("Shutting down io streams thread");
-                    break;
+                    message_tx
+                        .send(Message::Data(data.into()))
+                        .context("send data message")?;
                 }
+                Ok(n) if n == 0 => {
+                    debug!("No more to read");
+
+                    message_tx
+                        .send(Message::Done)
+                        .context("send done message")?;
+                    return Ok(());
+                }
+                Err(e) => match Errno::from_i32(e.raw_os_error().context("get OS error")?) {
+                    Errno::EIO => {
+                        debug!("Stopping read loop");
+
+                        message_tx
+                            .send(Message::Done)
+                            .context("send done message")?;
+                        return Ok(());
+                    }
+                    Errno::EBADF => {
+                        return Err(Errno::EBADFD.into());
+                    }
+                    Errno::EAGAIN => {
+                        continue;
+                    }
+                    _ => error!(
+                        "Unable to read from file descriptor: {} {}",
+                        e,
+                        e.raw_os_error().context("get OS error")?
+                    ),
+                },
+                _ => {}
             }
         }
-        Ok(())
     }
 }

--- a/conmon-rs/server/src/terminal.rs
+++ b/conmon-rs/server/src/terminal.rs
@@ -1,9 +1,8 @@
 //! Terminal console functionalities.
 
 use crate::{
-    container_io::Message,
+    container_io::{ContainerIO, Message},
     container_log::{Pipe, SharedContainerLog},
-    streams::Streams,
 };
 use anyhow::{bail, format_err, Context, Result};
 use getset::{Getters, MutGetters};
@@ -170,7 +169,7 @@ impl Terminal {
                             .connected_tx()
                             .send(())
                             .context("send connected channel")?;
-                        Streams::read_loop(fd, Pipe::StdOut, logger, config.message_tx).await
+                        ContainerIO::read_loop(fd, Pipe::StdOut, logger, config.message_tx).await
                     });
 
                     // TODO: Now that we have a fd to the tty, make sure we handle any pending

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -400,8 +400,13 @@ var _ = Describe("ConmonClient", func() {
 					expectedStr += "\r"
 				}
 				expectedStr += "\n"
-				Expect(result.Stdout).To(BeEquivalentTo(expectedStr))
-				Expect(result.Stderr).To(BeEmpty())
+				if terminal {
+					Expect(result.Stdout).To(BeEquivalentTo(expectedStr))
+					Expect(result.Stderr).To(BeEmpty())
+				} else {
+					Expect(result.Stdout).To(BeEmpty())
+					Expect(result.Stderr).To(BeEquivalentTo(expectedStr))
+				}
 			})
 
 			testName = "should timeout"

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -257,7 +257,7 @@ var _ = Describe("ConmonClient", func() {
 	Describe("ExecSyncContainer", func() {
 		for _, terminal := range []bool{false} {
 			terminal := terminal
-			testName := "should succeeed without timeout"
+			testName := "should succeed without timeout"
 			if terminal {
 				testName += " with terminal"
 			}
@@ -301,19 +301,15 @@ var _ = Describe("ConmonClient", func() {
 				Expect(result.Stdout).To(BeEquivalentTo("hello world"))
 				Expect(result.Stderr).To(BeEmpty())
 
-				// Log testing
-				logs := containerLogContents(logPath)
-				Expect(logs).To(ContainSubstring("stdout P hello world\n"))
-
 				sut.ReopenLogContainer(context.Background(), &client.ReopenLogContainerConfig{
 					ID: ctrID,
 				})
-				logs = containerLogContents(logPath)
+				logs := containerLogContents(logPath)
 				Expect(logs).To(BeEmpty())
 
 			})
 
-			testName = "should succeeed with timeout"
+			testName = "should succeed with timeout"
 			if terminal {
 				testName += " with terminal"
 			}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -255,7 +255,7 @@ var _ = Describe("ConmonClient", func() {
 		}
 	})
 
-	Describe("ExecSync Stress", func() {
+	FDescribe("ExecSync Stress", func() {
 		for _, terminal := range []bool{true, false} {
 			terminal := terminal
 			testName := "should handle many requests"
@@ -294,15 +294,17 @@ var _ = Describe("ConmonClient", func() {
 				for i := 0; i < 10; i++ {
 					wg.Add(1)
 					go func(i int) {
+						defer GinkgoRecover()
 						defer wg.Done()
 						result, err := sut.ExecSyncContainer(context.Background(), &client.ExecSyncConfig{
 							ID:       ctrID,
-							Command:  []string{"/busybox", "echo", "-n", "hello", "world"},
+							Command:  []string{"/busybox", "echo", "-n", "hello", "world", fmt.Sprintf("%d", i)},
 							Terminal: terminal,
 							Timeout:  timeoutUnlimited,
 						})
 						Expect(err).To(BeNil())
 						Expect(result).NotTo(BeNil())
+						Expect(result).To(Equal(fmt.Sprintf("hello world %d", i)))
 						fmt.Println("done with", i, string(result.Stdout))
 					}(i)
 				}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -255,7 +255,7 @@ var _ = Describe("ConmonClient", func() {
 	})
 
 	Describe("ExecSyncContainer", func() {
-		for _, terminal := range []bool{false} {
+		for _, terminal := range []bool{true, false} {
 			terminal := terminal
 			testName := "should succeed without timeout"
 			if terminal {


### PR DESCRIPTION
as they fundamentally shouldn't be very different.
    
Also, drop stop_rx from streams impl, as it is racy, include https://github.com/containers/conmon-rs/pull/329 and update a message from child_reaper