### PR TITLE
Bump clap to v3.1.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,16 +194,16 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.8"
+version = "3.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
+checksum = "6aad2534fad53df1cc12519c5cda696dd3e20e6118a027e24054aea14a0bdcbe"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
+ "clap_lex",
  "indexmap",
  "lazy_static",
- "os_str_bytes",
  "strsim",
  "termcolor",
  "terminal_size",
@@ -221,6 +221,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189ddd3b5d32a70b35e7686054371742a937b0d99128e76dde6340210e966669"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -651,9 +660,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.123"
+version = "0.2.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb691a747a7ab48abc15c5b42066eaafde10dc427e3b6ee2a1cf43db04c763bd"
+checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
 
 [[package]]
 name = "libgit2-sys"
@@ -881,9 +890,6 @@ name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "parking"

--- a/conmon-rs/server/Cargo.toml
+++ b/conmon-rs/server/Cargo.toml
@@ -13,7 +13,7 @@ capnp = "0.14.6"
 capnp-rpc = "0.14.1"
 chrono = "0.4.19"
 conmon-common = { path = "../common" }
-clap = { version = "3.1.5", features = ["cargo", "derive", "env", "wrap_help"] }
+clap = { version = "3.1.9", features = ["cargo", "derive", "env", "wrap_help"] }
 futures = "0.3.21"
 getset = "0.1.2"
 log = { version = "0.4.16", features = ["serde", "std"] }
@@ -22,7 +22,7 @@ simple_logger = "2.1.0"
 tokio = { version = "1.17.0", features = ["fs", "io-std", "io-util", "macros", "net", "process", "rt", "rt-multi-thread", "signal", "time"] }
 tokio-util = { version = "0.7.1", features = ["compat"] }
 nix = "0.23.1"
-libc = "0.2.123"
+libc = "0.2.124"
 memchr = "2.4.1"
 tempfile = "3.3.0"
 sendfd = { version = "0.4.1", features = ["tokio"] }


### PR DESCRIPTION
A while ago we excluded this dependency from dependabot while it seems
impossible to include it again. Means we now have to manually update it
every now and then.
