### PR TITLE
Reuse static binary in integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           key: ${{ runner.os }}-cargo-static-${{ hashFiles('**/Cargo.lock') }}
       - run: make release-static
       - run: target/x86_64-unknown-linux-musl/release/conmonrs -v
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: conmonrs
           path: target/x86_64-unknown-linux-musl/release/conmonrs
@@ -155,6 +155,7 @@ jobs:
         uses: codecov/codecov-action@v2
 
   test-integration:
+    needs: release-static
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v2
@@ -178,6 +179,12 @@ jobs:
           path: |
             /tmp/conmon-test-images
           key: ${{ runner.os }}-cargo-test-files-${{ hashFiles('pkg/client/files_test.go') }}
+      - run: rm -rf target/x86_64-unknown-linux-musl/release/conmonrs
+      - uses: actions/download-artifact@v3
+        with:
+          name: conmonrs
+          path: target/x86_64-unknown-linux-musl/release
+      - run: chmod +x target/x86_64-unknown-linux-musl/release/conmonrs
       - run: .github/install-deps
       - name: Integration tests
         run: RUNTIME_PATH="/usr/sbin/runc" make integration-static

--- a/Makefile
+++ b/Makefile
@@ -41,10 +41,13 @@ integration: .install.ginkgo release # It needs to be release so we correctly te
 	export MAX_RSS_KB=10240 && \
 	"$(GOTOOLS_BINDIR)/ginkgo" -v -r pkg/client
 
-integration-static: .install.ginkgo release-static # It needs to be release so we correctly test the RSS usage
+integration-static: .install.ginkgo # It needs to be release so we correctly test the RSS usage
 	export CONMON_BINARY="$(MAKEFILE_PATH)target/x86_64-unknown-linux-musl/release/$(BINARY)" && \
+	if [ ! -f "$$CONMON_BINARY" ]; then \
+		$(MAKE) release-static; \
+	fi && \
 	export RUNTIME_BINARY="$(RUNTIME_PATH)" && \
-	export MAX_RSS_KB=10240 && \
+	export MAX_RSS_KB=2500 && \
 	$(GOTOOLS_BINDIR)/ginkgo -v -r pkg/client
 
 .install.ginkgo:


### PR DESCRIPTION
We now re-use the pre-built binary in the integration tests to not build them multiple times,