### PR TITLE
Wrap stdio in structs for attach

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -284,12 +284,9 @@ var _ = Describe("ConmonClient", func() {
 						SocketPath: socketPath,
 						Tty:        terminal,
 						Streams: client.AttachStreams{
-							Stdin:        stdin,
-							Stdout:       stdout,
-							Stderr:       stderr,
-							AttachStdin:  true,
-							AttachStdout: true,
-							AttachStderr: true,
+							Stdin:  &client.In{stdin},
+							Stdout: &client.Out{stdout},
+							Stderr: &client.Out{stderr},
 						},
 					})
 					Expect(err).To(BeNil())


### PR DESCRIPTION
This allows that the values can be nil and makes the `Attach*` booleans obsolete.
