### PR TITLE
Add docs to reopen container logs RPC

### DIFF
--- a/conmon-rs/server/src/rpc.rs
+++ b/conmon-rs/server/src/rpc.rs
@@ -195,6 +195,7 @@ impl conmon::Server for Server {
         })
     }
 
+    /// Rotate all log drivers for a running container.
     fn reopen_log_container(
         &mut self,
         params: conmon::ReopenLogContainerParams,


### PR DESCRIPTION
The docs were missing from my previous patch, so we now ensure that this method has a docstring as well.
