### PR TITLE
Fix goerr113 lints

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,11 +2,6 @@
 run:
   concurrency: 6
   deadline: 5m
-issues:
-  exclude-rules:
-    - linters:
-        - goerr113
-      text: do not define dynamic errors, use wrapped static errors instead
 linters:
   disable-all: true
   enable:
@@ -85,6 +80,7 @@ linters:
     - unparam
     - unused
     - varcheck
+    - varnamelen
     - wastedassign
     - whitespace
     - wrapcheck
@@ -92,9 +88,10 @@ linters:
     # - forbidigo
     # - gochecknoglobals
     # - paralleltest
-    # - varnamelen
     # - wsl
 linters-settings:
+  varnamelen:
+    min-name-length: 1
   cyclop:
     max-complexity: 15
   gocognit:

--- a/pkg/client/attach.go
+++ b/pkg/client/attach.go
@@ -20,6 +20,11 @@ const (
 	attachPipeStderr    = 3
 )
 
+var (
+	errOutputDestNil   = errors.New("output destination cannot be nil")
+	errTerminalSizeNil = errors.New("terminal size cannot be nil")
+)
+
 // AttachStreams are the stdio streams for the AttachConfig.
 type AttachStreams struct {
 	// Standard input stream, can be nil.
@@ -219,7 +224,7 @@ func (c *ConmonClient) redirectResponseToOutputStreams(cfg *AttachConfig, conn i
 				c.logger.Infof("Received unexpected attach type %+d", buf[0])
 			}
 			if dst == nil {
-				return errors.New("output destination cannot be nil")
+				return errOutputDestNil
 			}
 
 			if doWrite {
@@ -311,7 +316,7 @@ type SetWindowSizeContainerConfig struct {
 // SetWindowSizeContainer can be used to change the window size of a running container.
 func (c *ConmonClient) SetWindowSizeContainer(ctx context.Context, cfg *SetWindowSizeContainerConfig) error {
 	if cfg.Size == nil {
-		return errors.New("terminal size cannot be nil")
+		return errTerminalSizeNil
 	}
 
 	conn, err := c.newRPCConn()

--- a/pkg/client/suite_test.go
+++ b/pkg/client/suite_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -279,6 +280,8 @@ func (rr *RuntimeRunner) RunCommand(args ...string) error {
 	return nil
 }
 
+var errNoMatch = errors.New("regex does not match")
+
 func (rr *RuntimeRunner) RunCommandCheckOutput(pattern string, args ...string) error {
 	stdoutString, err := rr.runCommand(args...)
 	if err != nil {
@@ -289,7 +292,7 @@ func (rr *RuntimeRunner) RunCommandCheckOutput(pattern string, args ...string) e
 		return fmt.Errorf("match regex pattern: %w", err)
 	}
 	if !match {
-		return fmt.Errorf("expected %s to be a substr of %s", pattern, stdoutString)
+		return fmt.Errorf("expected %s to be a substr of %s: %w", pattern, stdoutString, errNoMatch)
 	}
 
 	return nil


### PR DESCRIPTION
Enabling the excluded linter and pre-defining static errors while not exposing them to the API.