### PR TITLE
Make child reaper private again

### DIFF
--- a/conmon-rs/server/src/server.rs
+++ b/conmon-rs/server/src/server.rs
@@ -41,7 +41,7 @@ pub struct Server {
 
     /// reaper instance
     #[getset(get = "pub(crate)")]
-    pub reaper: Arc<ChildReaper>,
+    reaper: Arc<ChildReaper>,
 }
 
 impl Server {


### PR DESCRIPTION
We do not have to expose it via the public API so we make it crate public again via getset.