### PR TITLE
Make server config private

### DIFF
--- a/conmon-rs/server/src/server.rs
+++ b/conmon-rs/server/src/server.rs
@@ -35,11 +35,11 @@ use twoparty::VatNetwork;
 #[derive(Debug, Getters)]
 /// The main server structure.
 pub struct Server {
-    #[doc = "The server configuration."]
-    #[getset(get = "pub")]
+    /// Server configuration.
+    #[getset(get = "pub(crate)")]
     config: Config,
 
-    /// reaper instance
+    /// Child reaper instance.
     #[getset(get = "pub(crate)")]
     reaper: Arc<ChildReaper>,
 }


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup

#### What this PR does / why we need it:
The returned type is private so the method is unusable anyhow. Since we
cannot set the configuration from the outside we now make it private to
lower the API surface.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
