### PR TITLE
Sign static binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,10 @@ jobs:
 
   release-static:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    env:
+      COSIGN_EXPERIMENTAL: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -64,11 +68,22 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-static-${{ hashFiles('**/Cargo.lock') }}
       - run: make release-static
-      - run: target/x86_64-unknown-linux-musl/release/conmonrs -v
+      - run: |
+          mkdir ${{ github.sha }}
+          mv target/x86_64-unknown-linux-musl/release/conmonrs ${{ github.sha }}
+      - run: ./${{ github.sha }}/conmonrs -v
+      - uses: sigstore/cosign-installer@main
+      - name: Sign binary
+        if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags')
+        run: |
+          cd ${{ github.sha }}
+          cosign sign-blob conmonrs \
+            --output-signature conmonrs.sig \
+            --output-certificate conmonrs.cert
       - uses: actions/upload-artifact@v3
         with:
           name: conmonrs
-          path: target/x86_64-unknown-linux-musl/release/conmonrs
+          path: ${{ github.sha }}/*
       - uses: google-github-actions/auth@v0
         if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags')
         with:
@@ -76,8 +91,8 @@ jobs:
       - uses: google-github-actions/upload-cloud-storage@v0
         if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags')
         with:
-          path: target/x86_64-unknown-linux-musl/release/conmonrs
-          destination: cri-o/conmon-rs/${{ github.sha }}
+          path: ${{ github.sha }}
+          destination: cri-o/conmon-rs
       - run: .github/create-marker
         if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags')
       - uses: google-github-actions/upload-cloud-storage@v0

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ It is also possible to select a specific git SHA or the output binary path by:
     bash -s -- -t $GIT_SHA -o $OUTPUT_PATH
 ```
 
+The script automatically verifies the created sigstore signatures if the local
+system has [`cosign`](https://github.com/sigstore/cosign) available in its
+`$PATH`.
+
 [bucket]: https://console.cloud.google.com/storage/browser/cri-o/conmon-rs
 
 ## Architecture

--- a/scripts/get
+++ b/scripts/get
@@ -59,7 +59,28 @@ download_binary() {
     fi
 
     mkdir -p "$(dirname "$OUTPUT")"
-    curl_retry "$BASE_URL/$COMMIT/conmonrs" -o "$OUTPUT"
+
+    if command -v cosign2 >/dev/null; then
+        echo "Found cosign, verifying binary signature"
+        TMPDIR=$(mktemp -d)
+        trap 'rm -rf $TMPDIR' EXIT
+        pushd "$TMPDIR" >/dev/null
+
+        FILES=(conmonrs conmonrs.sig conmonrs.cert)
+        for FILE in "${FILES[@]}"; do
+            curl_retry "$BASE_URL/$COMMIT/$FILE" -o "$FILE"
+        done
+
+        COSIGN_EXPERIMENTAL=1 cosign verify-blob conmonrs \
+            --signature conmonrs.sig \
+            --certificate conmonrs.cert
+
+        popd >/dev/null
+        mv "$TMPDIR/conmonrs" "$OUTPUT"
+    else
+        curl_retry "$BASE_URL/$COMMIT/conmonrs" -o "$OUTPUT"
+    fi
+
     chmod +x "$OUTPUT"
     printf "Installed binary into: %s\n\n" "$OUTPUT"
     eval "$(realpath "$OUTPUT")" -v


### PR DESCRIPTION


#### What type of PR is this?


/kind feature

#### What this PR does / why we need it:

We now sign the produced binary within the CI and push the artifacts to the release bucket. The `get` script is capable of verifying the signature if `cosign` if found as binary in `$PATH`.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Automatically verify the `conmonrs` binary when using the `get` script if `cosign` is available in `$PATH`.
```
