### PR TITLE
Fix critest `runtime should support attach [Conformance]`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -93,6 +93,9 @@ linters:
     # - paralleltest
     # - wsl
 linters-settings:
+  funlen:
+    lines: 70
+    statements: 50
   varnamelen:
     min-name-length: 1
   cyclop:

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ integration-static: .install.ginkgo # It needs to be release so we correctly tes
 		$(MAKE) release-static; \
 	fi && \
 	export RUNTIME_BINARY="$(RUNTIME_PATH)" && \
-	export MAX_RSS_KB=3100 && \
+	export MAX_RSS_KB=3500 && \
 	sudo -E "$(GOTOOLS_BINDIR)/ginkgo" -v -r pkg/client
 
 .install.ginkgo:


### PR DESCRIPTION


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
We now indicate via a dedicated `DONE_PACKET` that we're finished writing all data, because we have no way to send `io.EOF` via the Rust API. This will fix the attach critest and allows the code paths to proceed.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixes https://github.com/containers/conmon-rs/issues/410
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed critest case `runtime should support attach [Conformance]`
```
