### PR TITLE
Fix IO busy loops

### DIFF
--- a/conmon-rs/server/src/server.rs
+++ b/conmon-rs/server/src/server.rs
@@ -88,10 +88,7 @@ impl Server {
             .map_err(errno::from_i32)
             .context("set child subreaper")?;
 
-        let rt = Builder::new_multi_thread()
-            .enable_io()
-            .enable_time()
-            .build()?;
+        let rt = Builder::new_multi_thread().enable_all().build()?;
         rt.block_on(self.spawn_tasks())?;
         rt.shutdown_background();
         Ok(())

--- a/pkg/client/attach.go
+++ b/pkg/client/attach.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"syscall"
 
 	"github.com/containers/common/pkg/resize"
 	"github.com/containers/common/pkg/util"
@@ -259,6 +260,11 @@ func (c *ConmonClient) redirectResponseToOutputStreams(cfg *AttachConfig, conn i
 		c.logger.WithError(er).Trace("Validating error")
 		if er == io.EOF {
 			break
+		}
+		if errors.Is(er, syscall.ECONNRESET) {
+			c.logger.WithError(er).Trace("Connection reset, retrying to read")
+
+			continue
 		}
 		if er != nil {
 			err = er


### PR DESCRIPTION
#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:

Both loops do not block the read, especially when no attach session is happening right now or the container produces no output. We fix that behavior by polling every 100ms.


#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed busy loops for reading container IO.
```
