### PR TITLE
Add support for `--cgroup-manager`

### DIFF
--- a/conmon-rs/server/src/config.rs
+++ b/conmon-rs/server/src/config.rs
@@ -88,6 +88,18 @@ pub struct Config {
     )]
     /// Do not fork if true
     skip_fork: bool,
+
+    #[get_copy = "pub"]
+    #[clap(
+        default_value(CgroupManager::Systemd.into()),
+        env(concat!(prefix!(), "CGROUP_MANAGER")),
+        long("cgroup-manager"),
+        short('c'),
+        possible_values(CgroupManager::iter().map(|x| x.into()).collect::<Vec<&str>>()),
+        value_name("MANAGER")
+    )]
+    /// Select the cgroup manager to be used
+    cgroup_manager: CgroupManager,
 }
 
 #[derive(
@@ -111,6 +123,29 @@ pub enum LogDriver {
 
     /// Use systemd journald as log driver
     Systemd,
+}
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    EnumIter,
+    EnumString,
+    Eq,
+    IntoStaticStr,
+    Hash,
+    PartialEq,
+    Serialize,
+)]
+#[strum(serialize_all = "lowercase")]
+/// Available cgroup managers.
+pub enum CgroupManager {
+    /// Use systemd to create and manage cgroups
+    Systemd,
+
+    /// Use the cgroup filesystem to create and manage cgroups
+    Cgroupfs,
 }
 
 impl Default for Config {

--- a/conmon-rs/server/src/server.rs
+++ b/conmon-rs/server/src/server.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     child_reaper::ChildReaper,
-    config::{Config, LogDriver},
+    config::{CgroupManager, Config, LogDriver},
     container_io::{ContainerIO, ContainerIOType},
     init::{DefaultInit, Init},
     version::Version,
@@ -219,6 +219,8 @@ impl Server {
         }
     }
 
+    const SYSTEMD_CGROUP_ARG: &'static str = "--systemd-cgroup";
+
     /// Generate the OCI runtime CLI arguments from the provided parameters.
     pub(crate) fn generate_runtime_args(
         &self,
@@ -231,6 +233,10 @@ impl Server {
 
         if let Some(rr) = self.config().runtime_root() {
             args.push(format!("--root={}", rr.display()));
+        }
+
+        if self.config().cgroup_manager() == CgroupManager::Systemd {
+            args.push(Self::SYSTEMD_CGROUP_ARG.into());
         }
 
         args.extend([
@@ -261,6 +267,10 @@ impl Server {
 
         if let Some(rr) = self.config().runtime_root() {
             args.push(format!("--root={}", rr.display()));
+        }
+
+        if self.config().cgroup_manager() == CgroupManager::Systemd {
+            args.push(Self::SYSTEMD_CGROUP_ARG.into());
         }
 
         args.push("exec".to_string());


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

We now can select a cgroup manager and set `--systemd-cgroup` on the OCI runtime level if systemd is selected (the default).

This fixes the passing of systemd related annotations to the config, for example: https://github.com/opencontainers/runc/pull/2224

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Using `--systemd-cgroup` for runtime commands.
```
