### PR TITLE
Read asynchronously from stdout/err

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-eventfd",
+ "tokio-fd",
  "tokio-util",
  "tracing",
  "tracing-journald",
@@ -1383,6 +1384,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435aa354af05ef661bac1f4fd46f1c635d7879bcf6c49303ce929e79bbd30f51"
 dependencies = [
  "futures-lite",
+ "libc",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-fd"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cedf0b897610a4baff98bf6116c060c5cfe7574d4339c50e9d23fe09377641d"
+dependencies = [
  "libc",
  "tokio",
 ]

--- a/conmon-rs/server/Cargo.toml
+++ b/conmon-rs/server/Cargo.toml
@@ -36,6 +36,7 @@ notify = "5.0.0-pre.15"
 tokio-eventfd = "0.2.0"
 lazy_static = "1.4.0"
 tz-rs = "0.6.11"
+tokio-fd = "0.3.0"
 
 [build-dependencies]
 shadow-rs = "0.16.1"

--- a/conmon-rs/server/src/streams.rs
+++ b/conmon-rs/server/src/streams.rs
@@ -81,14 +81,9 @@ impl Streams {
         if let Some(stdout) = stdout {
             task::spawn(
                 async move {
-                    if let Err(e) = ContainerIO::read_loop(
-                        stdout.as_raw_fd(),
-                        Pipe::StdOut,
-                        logger,
-                        message_tx,
-                        attach,
-                    )
-                    .await
+                    if let Err(e) =
+                        ContainerIO::read_loop(stdout, Pipe::StdOut, logger, message_tx, attach)
+                            .await
                     {
                         error!("Stdout read loop failure: {:#}", e);
                     }
@@ -103,14 +98,9 @@ impl Streams {
         if let Some(stderr) = stderr {
             task::spawn(
                 async move {
-                    if let Err(e) = ContainerIO::read_loop(
-                        stderr.as_raw_fd(),
-                        Pipe::StdErr,
-                        logger,
-                        message_tx,
-                        attach,
-                    )
-                    .await
+                    if let Err(e) =
+                        ContainerIO::read_loop(stderr, Pipe::StdErr, logger, message_tx, attach)
+                            .await
                     {
                         error!("Stderr read loop failure: {:#}", e);
                     }


### PR DESCRIPTION


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
This removes the need for the tick interval for the `read_loop` and should also fix the failing critest suite.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
