### PR TITLE
Add `FromLogrusLevel` helper

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -113,6 +113,31 @@ func NewConmonServerConfig(
 	}
 }
 
+// FromLogrusLevel converts the logrus.Level to a conmon-rs server log level.
+func FromLogrusLevel(level logrus.Level) string {
+	switch level {
+	case logrus.PanicLevel, logrus.FatalLevel:
+		return LogLevelOff
+
+	case logrus.ErrorLevel:
+		return LogLevelError
+
+	case logrus.WarnLevel:
+		return LogLevelWarn
+
+	case logrus.InfoLevel:
+		return LogLevelInfo
+
+	case logrus.DebugLevel:
+		return LogLevelDebug
+
+	case logrus.TraceLevel:
+		return LogLevelTrace
+	}
+
+	return LogLevelDebug
+}
+
 // New creates a new conmon server, starts it and connects a new client to it.
 func New(config *ConmonServerConfig) (client *ConmonClient, retErr error) {
 	cl, err := config.toClient()


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
This allows easy type conversion between the log levels and avoids mismatches like "warn" (conmon-rs) and "warning" (logrus).

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `FromLogrusLevel` helper function.
```
