### PR TITLE
Autobuild Copr RPM after every PR merge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,3 +89,9 @@ create-release-packages: release
 install:
 	mkdir -p "${DESTDIR}$(PREFIX)/bin"
 	install -D -t "${DESTDIR}$(PREFIX)/bin" target/release/conmonrs
+
+# Only meant to build the latest HEAD commit + any uncommitted changes
+# Not a replacement for the distro package
+.PHONY: rpm
+rpm:
+	rpkg local

--- a/conmon-rs.spec.rpkg
+++ b/conmon-rs.spec.rpkg
@@ -1,0 +1,53 @@
+# The following tag is to get correct syntax highlighting for this file in vim text editor
+# vim: syntax=spec
+
+# This spec file is used for automatic rebuilds in COPR
+# This is not the official spec file for any distro
+
+%global with_debug 0
+
+%if 0%{?with_debug}
+%global _find_debuginfo_dwz_opts %{nil}
+%global _dwz_low_mem_die_limit 0
+%else
+%global debug_package %{nil}
+%endif
+
+%global bin_name conmonrs
+
+Name: {{{ git_dir_name }}}
+Epoch: 101
+Version: {{{ git_dir_version }}}
+Release: 1%{?dist}
+Summary: Container monitor in Rust
+License: ASL 2.0 and BSD and ISC and MIT
+URL: https://github.com/containers/conmon-rs
+VCS: {{{ git_dir_vcs }}}
+Source: {{{ git_dir_pack }}}
+BuildRequires: capnproto
+BuildRequires: cargo
+BuildRequires: git-core
+BuildRequires: make
+Provides: %{bin_name}
+ExclusiveArch: %{rust_arches}
+
+%global _description %{expand:
+%{summary}}
+
+%description %{_description}
+
+%prep
+{{{ git_dir_setup_macro }}}
+
+%build
+%{__make} release
+
+%install
+%{__make} DESTDIR=%{buildroot} PREFIX=%{_prefix} install
+
+%files
+%license LICENSE
+%{_bindir}/%{bin_name}
+
+%changelog
+{{{ git_dir_changelog }}}


### PR DESCRIPTION
This commit includes a `conmon-rs.spec.rpkg` which along with a webhook
added to the conmon-rs repo will trigger automatic rpm builds on the
`rhcontainerbot/podman-next` copr repo.

With this change, a user can:
```
$ sudo dnf -y copr enable rhcontainerbot/podman-next
$ sudo dnf -y install conmon-rs
```

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/containers/conmon-rs/blob/main/CONTRIBUTING.md) as well as
ensuring that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind other

#### What this PR does / why we need it:

Allows conmon-rs users to conveniently use the latest upstream features via rpms

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

None


#### Special notes for your reviewer:

Try running `make rpm` locally using this fork or try installing the package from the copr.

Successful build at: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/build/4703775/

f36 x86_64 rpm at: https://download.copr.fedorainfracloud.org/results/rhcontainerbot/podman-next/fedora-36-x86_64/04703775-conmon-rs/

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

@haircommander @rphillips PTAL
/cc @cevich

I have added the webhook already. Once this PR gets merged, it should trigger autobuilds.