### PR TITLE
fix s390x and armhfp builds

### DIFF
--- a/conmon-rs/server/src/oom_watcher.rs
+++ b/conmon-rs/server/src/oom_watcher.rs
@@ -15,7 +15,16 @@ use tracing::{debug, debug_span, error, Instrument};
 
 #[cfg(any(all(target_os = "linux", target_env = "musl")))]
 pub const CGROUP2_SUPER_MAGIC: FsType = FsType(libc::CGROUP2_SUPER_MAGIC as u64);
-#[cfg(any(all(target_os = "linux", not(target_env = "musl"))))]
+#[cfg(any(all(target_os = "linux", target_arch = "s390x", not(target_env = "musl"))))]
+pub const CGROUP2_SUPER_MAGIC: FsType = FsType(libc::CGROUP2_SUPER_MAGIC as u32);
+#[cfg(any(all(target_os = "linux", target_arch = "armhfp", not(target_env = "musl"))))]
+pub const CGROUP2_SUPER_MAGIC: FsType = FsType(libc::CGROUP2_SUPER_MAGIC as i32);
+#[cfg(any(all(
+    target_os = "linux",
+    not(target_arch = "s390x"),
+    not(target_arch = "armhfp"),
+    not(target_env = "musl")
+)))]
 pub const CGROUP2_SUPER_MAGIC: FsType = FsType(libc::CGROUP2_SUPER_MAGIC as i64);
 
 static CGROUP_ROOT: &str = "/sys/fs/cgroup";


### PR DESCRIPTION
Should fix #603 

```release-note
fix cgroup2 super magic variable to be cross platform
```