### PR TITLE
Downgrade anyhow to fix gh-pages build

### DIFF
--- a/conmon-rs/server/Cargo.toml
+++ b/conmon-rs/server/Cargo.toml
@@ -8,7 +8,7 @@ name = "conmonrs"
 path = "src/main.rs"
 
 [dependencies]
-anyhow = "1.0.60"
+anyhow = "1.0.59"
 capnp = "0.14.8"
 capnp-rpc = "0.14.1"
 conmon-common = { path = "../common" }


### PR DESCRIPTION

#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:

v1.0.60 has been yanked from crates.io, which also makes gh-pages fail with:
```
error: failed to select a version for the requirement `anyhow = "^1.0.60"`
```

We now downgrade the version to fix failing builds.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
