### PR TITLE
cancel I/O (notably attach) when container exits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ lint-go: .install.golangci-lint
 	GL_DEBUG=gocritic $(GOTOOLS_BINDIR)/golangci-lint run
 
 unit:
-	cargo test --bins --no-fail-fast
+	cargo test --no-fail-fast
 
 integration: .install.ginkgo release # It needs to be release so we correctly test the RSS usage
 	export CONMON_BINARY="$(MAKEFILE_PATH)target/release/$(BINARY)" && \

--- a/conmon-rs/server/src/child.rs
+++ b/conmon-rs/server/src/child.rs
@@ -2,6 +2,7 @@ use crate::container_io::SharedContainerIO;
 use getset::{CopyGetters, Getters};
 use std::path::PathBuf;
 use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
 
 #[derive(Debug, CopyGetters, Getters)]
 pub struct Child {
@@ -25,9 +26,13 @@ pub struct Child {
 
     #[getset(get = "pub")]
     cleanup_cmd: Vec<String>,
+
+    #[getset(get = "pub")]
+    token: CancellationToken,
 }
 
 impl Child {
+    #![allow(clippy::too_many_arguments)]
     pub fn new(
         id: String,
         pid: u32,
@@ -36,6 +41,7 @@ impl Child {
         timeout: Option<Instant>,
         io: SharedContainerIO,
         cleanup_cmd: Vec<String>,
+        token: CancellationToken,
     ) -> Self {
         Self {
             id,
@@ -45,6 +51,7 @@ impl Child {
             timeout,
             io,
             cleanup_cmd,
+            token,
         }
     }
 }

--- a/conmon-rs/server/src/container_io.rs
+++ b/conmon-rs/server/src/container_io.rs
@@ -162,9 +162,15 @@ impl ContainerIO {
     ) -> (Vec<u8>, Vec<u8>, bool) {
         match self.typ_mut() {
             ContainerIOType::Terminal(t) => {
-                let (stdout, timed_out) =
-                    Self::read_stream_with_timeout(time_to_timeout, t.message_rx_mut()).await;
-                (stdout, vec![], timed_out)
+                if let Some(message_rx) = t.message_rx_mut() {
+                    let (stdout, timed_out) =
+                        Self::read_stream_with_timeout(time_to_timeout, message_rx).await;
+                    (stdout, vec![], timed_out)
+                } else {
+                    // TODO FIXME
+                    error!("read_all_with_timeout called before message_rx was registered");
+                    (vec![], vec![], false)
+                }
             }
             ContainerIOType::Streams(s) => {
                 let stdout_rx = &mut s.message_rx_stdout;

--- a/conmon-rs/server/src/terminal.rs
+++ b/conmon-rs/server/src/terminal.rs
@@ -22,7 +22,7 @@ use tokio::{
     fs,
     io::{AsyncWriteExt, Interest},
     net::UnixStream,
-    sync::mpsc::{self, Receiver, Sender, UnboundedReceiver, UnboundedSender},
+    sync::mpsc::{self, Receiver, Sender, UnboundedReceiver},
     task,
 };
 use tokio_fd::AsyncFd;
@@ -36,10 +36,13 @@ pub struct Terminal {
     connected_rx: Receiver<RawFd>,
 
     #[getset(get = "pub", get_mut = "pub")]
-    message_rx: UnboundedReceiver<Message>,
+    message_rx: Option<UnboundedReceiver<Message>>,
 
     #[getset(get, set)]
     tty: Option<RawFd>,
+
+    logger: SharedContainerLog,
+    attach: SharedContainerAttach,
 }
 
 #[derive(Debug, Getters)]
@@ -52,9 +55,6 @@ struct Config {
 
     #[get]
     connected_tx: Sender<RawFd>,
-
-    #[get]
-    message_tx: UnboundedSender<Message>,
 }
 
 impl Terminal {
@@ -66,20 +66,14 @@ impl Terminal {
 
         let (ready_tx, ready_rx) = std::sync::mpsc::channel();
         let (connected_tx, connected_rx) = mpsc::channel(1);
-        let (message_tx, message_rx) = mpsc::unbounded_channel();
 
         task::spawn(
             async move {
-                if let Err(e) = Self::listen(
-                    Config {
-                        path: path_clone,
-                        ready_tx,
-                        connected_tx,
-                        message_tx,
-                    },
-                    logger,
-                    attach,
-                )
+                if let Err(e) = Self::listen(Config {
+                    path: path_clone,
+                    ready_tx,
+                    connected_tx,
+                })
                 .await
                 {
                     error!("Unable to listen on terminal: {:#}", e);
@@ -92,8 +86,10 @@ impl Terminal {
         Ok(Self {
             path,
             connected_rx,
-            message_rx,
+            message_rx: None,
             tty: None,
+            logger,
+            attach,
         })
     }
 
@@ -106,6 +102,47 @@ impl Terminal {
             .await
             .context("receive connected channel")?;
         self.set_tty(fd.into());
+
+        debug!("Changing terminal settings");
+        let mut term = termios::tcgetattr(fd)?;
+        term.output_flags |= OutputFlags::ONLCR;
+        termios::tcsetattr(fd, SetArg::TCSANOW, &term)?;
+
+        let stdio = AsyncFd::try_from(fd)?;
+
+        let attach_clone = self.attach.clone();
+        let logger_clone = self.logger.clone();
+        let (message_tx, message_rx) = mpsc::unbounded_channel();
+        self.message_rx = Some(message_rx);
+
+        task::spawn(
+            async move {
+                if let Err(e) = ContainerIO::read_loop(
+                    stdio,
+                    Pipe::StdOut,
+                    logger_clone,
+                    message_tx,
+                    attach_clone,
+                )
+                .await
+                {
+                    error!("Stdout read loop failure: {:#}", e)
+                }
+                Ok::<_, anyhow::Error>(())
+            }
+            .instrument(debug_span!("read_loop")),
+        );
+
+        let attach_clone = self.attach.clone();
+        task::spawn(
+            async move {
+                if let Err(e) = ContainerIO::read_loop_stdin(fd, attach_clone).await {
+                    error!("Stdin read loop failure: {:#}", e);
+                }
+            }
+            .instrument(debug_span!("read_loop_stdin")),
+        );
+
         Ok(())
     }
 
@@ -130,11 +167,7 @@ impl Terminal {
         }
     }
 
-    async fn listen(
-        config: Config,
-        logger: SharedContainerLog,
-        attach: SharedContainerAttach,
-    ) -> Result<()> {
+    async fn listen(config: Config) -> Result<()> {
         let path = config.path();
         debug!("Listening terminal socket on {}", path.display());
         let listener = Listener::<DefaultListener>::default().bind_long_path(path)?;
@@ -152,15 +185,10 @@ impl Terminal {
         let stream = listener.accept().await?.0;
         debug!("Got terminal socket stream: {:?}", stream);
 
-        Self::handle_fd_receive(stream, config, logger, attach).await
+        Self::handle_fd_receive(stream, config).await
     }
 
-    async fn handle_fd_receive(
-        mut stream: UnixStream,
-        config: Config,
-        logger: SharedContainerLog,
-        attach: SharedContainerAttach,
-    ) -> Result<()> {
+    async fn handle_fd_receive(mut stream: UnixStream, config: Config) -> Result<()> {
         loop {
             if !stream.ready(Interest::READABLE).await?.is_readable() {
                 continue;
@@ -187,45 +215,11 @@ impl Terminal {
                     debug!("Received terminal file descriptor");
                     let fd = fd_buffer[0];
 
-                    debug!("Changing terminal settings");
-                    let mut term = termios::tcgetattr(fd)?;
-                    term.output_flags |= OutputFlags::ONLCR;
-                    termios::tcsetattr(fd, SetArg::TCSANOW, &term)?;
-
-                    let stdio = AsyncFd::try_from(fd)?;
-
-                    let attach_clone = attach.clone();
-                    task::spawn(
-                        async move {
-                            config
-                                .connected_tx
-                                .send(fd)
-                                .await
-                                .context("send connected channel")?;
-                            if let Err(e) = ContainerIO::read_loop(
-                                stdio,
-                                Pipe::StdOut,
-                                logger,
-                                config.message_tx,
-                                attach_clone,
-                            )
-                            .await
-                            {
-                                error!("Stdout read loop failure: {:#}", e)
-                            }
-                            Ok::<_, anyhow::Error>(())
-                        }
-                        .instrument(debug_span!("read_loop")),
-                    );
-
-                    task::spawn(
-                        async move {
-                            if let Err(e) = ContainerIO::read_loop_stdin(fd, attach).await {
-                                error!("Stdin read loop failure: {:#}", e);
-                            }
-                        }
-                        .instrument(debug_span!("read_loop_stdin")),
-                    );
+                    config
+                        .connected_tx
+                        .send(fd)
+                        .await
+                        .context("send connected channel")?;
 
                     debug!("Shutting down listener thread");
                     return Ok(());

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -373,7 +373,6 @@ var _ = Describe("ConmonClient", func() {
 			terminal := test.terminal
 			pipe := test.pipe
 			It(testName("should succeed with "+test.pipe, test.terminal), func() {
-
 				tr = newTestRunner()
 				tr.createRuntimeConfigWithProcessArgs(terminal, []string{"/busybox", "sh"}, nil)
 				sut = tr.configGivenEnv()

--- a/pkg/client/suite_test.go
+++ b/pkg/client/suite_test.go
@@ -439,10 +439,12 @@ func verifyBuffer(reader io.Reader, terminal bool, command, expected string) {
 		data := make([]byte, 8191)
 		_, err := reader.Read(data)
 		Expect(err).To(BeNil())
+
 		return string(bytes.Trim(data, "\x00"))
 	}
 	if !terminal {
 		Expect(readSection()).To(Equal(expected))
+
 		return
 	}
 
@@ -454,6 +456,7 @@ func verifyBuffer(reader io.Reader, terminal bool, command, expected string) {
 			continue
 		}
 		Expect(str).To(Equal(fullExpectedBuffer))
+
 		return
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/containers/conmon-rs/blob/main/CONTRIBUTING.md) as well as
ensuring that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->
/kind bug
#### What this PR does / why we need it:
Previously, the attach code was sending Done too early. This caused clients to detach early while there was still output to process. It previously used the "no output" condition to decide that there was no more output. However, it seems the read pipe will send `n == 0` (which I think should be looked into separately)

Really, the condition to stop the attach are two-fold: client detaches, or container exits. the former case should be handled. This PR adds the latter case by using a cancellation token and wiring it throughout the I/O code.

A followup should be checking that we're not CPU cycling when we get no output from the pipes (`n == 0` cases that were dropped) 
#### Which issue(s) this PR fixes:
fixes https://github.com/containers/conmon-rs/issues/620
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug where the server would detach from an attach session too early
```
