### PR TITLE
Close attach readers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	capnproto.org/go/capnp/v3 v3.0.0-alpha.5
 	github.com/containers/common v0.49.1
 	github.com/containers/storage v1.42.0
+	github.com/google/uuid v1.3.0
 	github.com/onsi/ginkgo/v2 v2.1.6
 	github.com/onsi/gomega v1.20.2
 	github.com/opencontainers/runc v1.1.4

--- a/go.sum
+++ b/go.sum
@@ -373,6 +373,7 @@ github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=

--- a/pkg/client/suite_test.go
+++ b/pkg/client/suite_test.go
@@ -56,7 +56,9 @@ func TestConmonClient(t *testing.T) {
 
 var _ = AfterSuite(func() {
 	By("printing the goroutine stack for debugging purposes")
-	Expect(pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)).To(BeNil())
+	goroutines := pprof.Lookup("goroutine")
+	Expect(goroutines.WriteTo(os.Stdout, 1)).To(BeNil())
+	Expect(goroutines.Count()).To(Equal(5))
 
 	By("Verifying that no conmonrs processes are still running in the background")
 	cmd := exec.Command("ps", "aux")


### PR DESCRIPTION


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
We now close outstanding `Read()` operations on `CopyDetachable` for each attach session. The conmon client collects all attach sessions and also closes them on `Shutdown`.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixes #534 
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Cleanup attach sessions to not leak any goroutine.
```
