### PR TITLE
Add critest run to CI

### DIFF
--- a/.github/setup
+++ b/.github/setup
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+main() {
+    set -x
+    prepare_system
+
+    install_critest
+    install_crio
+}
+
+curl_retry() {
+    curl -sSfL --retry 5 --retry-delay 3 "$@"
+}
+
+prepare_system() {
+    sudo systemctl stop docker
+    sudo ufw disable
+
+    # enable necessary kernel modules
+    sudo ip6tables --list >/dev/null
+
+    # enable necessary sysctls
+    sudo sysctl -w net.ipv4.conf.all.route_localnet=1
+    sudo sysctl -w net.ipv4.ip_forward=1
+
+    # needed for crictl test
+    sudo sysctl -w net.bridge.bridge-nf-call-iptables=1
+    sudo iptables -t nat -I POSTROUTING -s 127.0.0.0/8 ! -d 127.0.0.0/8 -j MASQUERADE
+
+    if ! grep -q containers /etc/subuid; then
+        echo "containers:100000:65536" | sudo tee -a /etc/subuid
+    fi
+    if ! grep -q containers /etc/subgid; then
+        echo "containers:100000:65536" | sudo tee -a /etc/subgid
+    fi
+
+    printf "RateLimitInterval=0\nRateLimitBurst=0\n" | sudo tee /etc/systemd/journald.conf
+    sudo systemctl restart systemd-journald
+}
+
+install_crio() {
+    curl_retry "https://raw.githubusercontent.com/cri-o/cri-o/main/scripts/get" |
+        sudo bash -s --
+
+    cat <<EOT | sudo tee /etc/crio/crio.conf.d/10-crun.conf
+[crio.runtime]
+default_runtime = "runc"
+seccomp_use_default_when_empty = false
+
+[crio.runtime.runtimes.runc]
+runtime_type = "pod"
+EOT
+
+    sudo systemctl enable --now crio.service
+
+    # Validate if the correct config is being loaded
+    sudo crio-status config | grep -q 'default_runtime = "runc"'
+    sudo crio-status config | grep -q 'runtime_type = "pod"'
+}
+
+install_critest() {
+    TAG=v1.25.0
+    curl_retry "https://storage.googleapis.com/k8s-artifacts-cri-tools/release/$TAG/critest-$TAG-linux-amd64.tar.gz" |
+        sudo tar xfz - -C /usr/local/bin
+}
+
+main "$@"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,3 +245,20 @@ jobs:
         run: |
           sudo chown -R $(id -u):$(id -g) ~/go/pkg/mod
           sudo chown -R $(id -u):$(id -g) ~/.cache/go-build
+
+  test-critest:
+    needs: release-static
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: conmonrs
+          path: target/x86_64-unknown-linux-musl/release
+      - run: sudo cp target/x86_64-unknown-linux-musl/release/conmonrs /usr/local/bin
+      - run: sudo chmod +x /usr/local/bin/conmonrs
+      - run: .github/setup
+      - name: Run critest
+        run: sudo critest


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

We now run a critest suite with a pinned CRI-O release for each PR.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Needs https://github.com/containers/conmon-rs/pull/702 to not timeout during the attach test.

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
