### PR TITLE
Reduce memory usage for attach

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ members = [
 ]
 
 [profile.release]
+debug = 2
 lto = true
 opt-level = "z"
+strip = true
+incremental = true
 codegen-units = 1

--- a/conmon-rs/server/src/attach.rs
+++ b/conmon-rs/server/src/attach.rs
@@ -39,8 +39,8 @@ pub struct SharedContainerAttach {
 
 impl Default for SharedContainerAttach {
     fn default() -> Self {
-        let (read_half_tx, read_half_rx) = broadcast::channel(1000);
-        let (write_half_tx, _) = broadcast::channel(1000);
+        let (read_half_tx, read_half_rx) = broadcast::channel(4);
+        let (write_half_tx, _) = broadcast::channel(4);
         Self {
             read_half_rx,
             read_half_tx,
@@ -250,7 +250,7 @@ impl Attach {
 
     async fn write_loop(mut write_half: OwnedWriteHalf, mut rx: Receiver<Message>) -> Result<()> {
         loop {
-            match rx.recv().await? {
+            match rx.recv().await.context("receive message")? {
                 Message::Done => {
                     debug!("Exiting because token cancelled");
                     match write_half.write(Self::DONE_PACKET).await {


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup

#### What this PR does / why we need it:
It's unrealistic that we have to buffer 1000 packets, especially since they should be consumed by in a fast manner. We now still keep a safe zone of 4 packets in the channel, but this already reduces the memory by multiple hundred kilobytes.

We also optimize the release build by stripping of the binary as well as removing the debug symbols per default.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
