### PR TITLE
Fix server shutdown if conmon-rs got manually killed

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -793,6 +793,11 @@ func (c *ConmonClient) Shutdown() error {
 
 	pid := int(c.serverPID)
 	if err := syscall.Kill(pid, syscall.SIGINT); err != nil {
+		// Process does not exist any more, it might be manually killed.
+		if errors.Is(err, syscall.ESRCH) {
+			return nil
+		}
+
 		return fmt.Errorf("kill server PID: %w", err)
 	}
 


### PR DESCRIPTION


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
We should not fail in case conmon-rs got killed by another instance, because this would trigger an error in sandbox removal in CRI-O and therefore makes it impossible to remove the sandbox. We now double check if the PID still exists before going into the wait loop.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed server shutdown error if PID does not exist any more.
```
