### PR TITLE
Remove attach socket path if not in use

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -41,7 +41,7 @@ type ConmonClient struct {
 	serverPID     uint32
 	runDir        string
 	logger        *logrus.Logger
-	attachReaders *sync.Map
+	attachReaders *sync.Map // K: UUID string, V: *attachReaderValue
 }
 
 // ConmonServerConfig is the configuration for the conmon server instance.


### PR DESCRIPTION

#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
We cannot really know if the unix listener is still in use from the conmon-rs perspective, because it could be possible that conmonrs got killed while still having readers open on the client side.

We now add a cleanup logic to the client to remove the socket path if no readers are available any more. This allows conmonrs to still create multiple socket paths in parallel and keep them open until all clients are gone, the container terminates or the server does a shutdown.
#### Which issue(s) this PR fixes:
Closes https://github.com/containers/conmon-rs/issues/706
<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Cleanup unused attach sockets on the client side if all readers are dropped, the container exits or the server does a shutdown.
```
