### PR TITLE
Send only streams data if channel is not closed

### DIFF
--- a/conmon-rs/server/src/container_io.rs
+++ b/conmon-rs/server/src/container_io.rs
@@ -267,9 +267,11 @@ impl ContainerIO {
                                 .await
                                 .context("write to attach endpoints")?;
 
-                            message_tx
-                                .send(Message::Data(data.into(), pipe))
-                                .context("send data message")?;
+                            if !message_tx.is_closed() {
+                                message_tx
+                                    .send(Message::Data(data.into(), pipe))
+                                    .context("send data message")?;
+                            }
                         }
                         Err(e) => match Errno::from_i32(e.raw_os_error().context("get OS error")?) {
                             Errno::EIO => {


### PR DESCRIPTION
#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:

The stream data is only read on `read_all_with_timeout`, which is called via exec sync or on on container creation error. This means we can end-up having a closed sender, but we should not fail in this case because it will lead into unexpected container termination.


#### Which issue(s) this PR fixes:

Fixes https://github.com/containers/conmon-rs/issues/720

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed bug where a closed stream sender causes container termination.
```
