### PR TITLE
Remove token from ContainerIO read_loop

### DIFF
--- a/conmon-rs/server/src/streams.rs
+++ b/conmon-rs/server/src/streams.rs
@@ -65,12 +65,11 @@ impl Streams {
         let attach = self.attach().clone();
         let message_tx = self.message_tx_stdout().clone();
 
-        let token_clone = token.clone();
         if let Some(stdin) = stdin {
             task::spawn(
                 async move {
                     if let Err(e) =
-                        ContainerIO::read_loop_stdin(stdin.as_raw_fd(), attach, token_clone).await
+                        ContainerIO::read_loop_stdin(stdin.as_raw_fd(), attach, token).await
                     {
                         error!("Stdin read loop failure: {:#}", e);
                     }
@@ -80,19 +79,12 @@ impl Streams {
         }
 
         let attach = self.attach().clone();
-        let token_clone = token.clone();
         if let Some(stdout) = stdout {
             task::spawn(
                 async move {
-                    if let Err(e) = ContainerIO::read_loop(
-                        stdout,
-                        Pipe::StdOut,
-                        logger,
-                        message_tx,
-                        attach,
-                        token_clone,
-                    )
-                    .await
+                    if let Err(e) =
+                        ContainerIO::read_loop(stdout, Pipe::StdOut, logger, message_tx, attach)
+                            .await
                     {
                         error!("Stdout read loop failure: {:#}", e);
                     }
@@ -107,15 +99,9 @@ impl Streams {
         if let Some(stderr) = stderr {
             task::spawn(
                 async move {
-                    if let Err(e) = ContainerIO::read_loop(
-                        stderr,
-                        Pipe::StdErr,
-                        logger,
-                        message_tx,
-                        attach,
-                        token,
-                    )
-                    .await
+                    if let Err(e) =
+                        ContainerIO::read_loop(stderr, Pipe::StdErr, logger, message_tx, attach)
+                            .await
                     {
                         error!("Stderr read loop failure: {:#}", e);
                     }

--- a/conmon-rs/server/src/terminal.rs
+++ b/conmon-rs/server/src/terminal.rs
@@ -115,7 +115,6 @@ impl Terminal {
         let logger_clone = self.logger.clone();
         let (message_tx, message_rx) = mpsc::unbounded_channel();
         self.message_rx = Some(message_rx);
-        let token_clone = token.clone();
 
         task::spawn(
             async move {
@@ -125,7 +124,6 @@ impl Terminal {
                     logger_clone,
                     message_tx,
                     attach_clone,
-                    token_clone,
                 )
                 .await
                 {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -118,8 +118,8 @@ var _ = Describe("ConmonClient", func() {
 			})
 
 			It(testName("should execute cleanup command when container exits", terminal), func() {
-				filepath := fmt.Sprintf("%s/conmon-client-test%s", os.TempDir(), tr.ctrID)
 				tr = newTestRunner()
+				filepath := fmt.Sprintf("%s/conmon-client-test%s", os.TempDir(), tr.ctrID)
 				tr.createRuntimeConfig(terminal)
 				sut = tr.configGivenEnv()
 				tr.createContainerWithConfig(sut, &client.CreateContainerConfig{
@@ -312,7 +312,7 @@ var _ = Describe("ConmonClient", func() {
 				rssAfter := vmRSSGivenPID(pid)
 				GinkgoWriter.Printf("VmRSS after: %d\n", rssAfter)
 				GinkgoWriter.Printf("VmRSS diff: %d\n", rssAfter-rssBefore)
-				Expect(rssAfter - rssBefore).To(BeNumerically("<", 1000))
+				Expect(rssAfter - rssBefore).To(BeNumerically("<", 1200))
 			})
 		}
 	})


### PR DESCRIPTION
#### What type of PR is this?


/kind bug

#### What this PR does / why we need it:

This allows the read loop to finish one there is nothing more to read.

#### Which issue(s) this PR fixes:

Fixes #738 

#### Special notes for your reviewer:

This is fixing the GitHub actions e2e tests in CRI-O: https://github.com/cri-o/cri-o/actions/runs/3098295877/jobs/5017090180

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed bug where read loop races with the container exit.
```
