### PR TITLE
WIP: Reduce default ContainerIO memory usage

### DIFF
--- a/conmon-rs/server/src/container_io.rs
+++ b/conmon-rs/server/src/container_io.rs
@@ -240,7 +240,7 @@ impl ContainerIO {
     where
         T: AsyncRead + Unpin,
     {
-        let mut buf = vec![0; 1024];
+        let mut buf = vec![0; 64];
 
         loop {
             // In situations we're processing output directly from the I/O streams


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Most IO messages will not take 1024 bytes so we can start with a much lower amount of memory here.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Reduced default memory usage of `ContainerIO`.
```
