### PR TITLE
Read once again after stdin token cancelled

### DIFF
--- a/conmon-rs/server/src/attach.rs
+++ b/conmon-rs/server/src/attach.rs
@@ -83,6 +83,13 @@ impl SharedContainerAttach {
             .context("receive attach message")
     }
 
+    /// Try to read from all attach endpoints standard input and return the first result.
+    pub fn try_read(&mut self) -> Result<Vec<u8>> {
+        self.read_half_rx
+            .try_recv()
+            .context("try to receive attach message")
+    }
+
     /// Write a buffer to all attach endpoints.
     pub async fn write(&mut self, m: Message) -> Result<()> {
         if self.write_half_tx.receiver_count() > 0 {

--- a/pkg/client/attach.go
+++ b/pkg/client/attach.go
@@ -376,7 +376,6 @@ func (c *ConmonClient) readStdio(
 
 	case err = <-stdinDone:
 		c.logger.WithError(err).Trace("Received message on input channel")
-		c.tryCloseAttachReaderForID(id)
 
 		// This particular case is for when we get a non-tty attach
 		// with --leave-stdin-open=true. We want to return as soon
@@ -386,6 +385,9 @@ func (c *ConmonClient) readStdio(
 		if cfg.StopAfterStdinEOF {
 			return nil
 		}
+
+		c.tryCloseAttachReaderForID(id)
+
 		if errors.Is(err, util.ErrDetach) {
 			if closeErr := conn.CloseWrite(); closeErr != nil {
 				return fmt.Errorf("%v: %w", closeErr, err)


### PR DESCRIPTION


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
This fixes the first test of `should support inline execution and attach`:

https://github.com/kubernetes/kubernetes/blob/7f129f1c9af62cc3cd4f6b754dacdf5932f39d5c/test/e2e/kubectl/kubectl.go#L603-L612

Short lived attach sessions may have some more content to read after they exited, which is now fixed by trying another read after the token has been canceled via the waitpid exit.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://github.com/containers/conmon-rs/issues/736
#### Special notes for your reviewer:
The `--leave-stdin-open=true` tests are still failing, but those have to be fixed in another PR:

https://github.com/kubernetes/kubernetes/blob/7f129f1c9af62cc3cd4f6b754dacdf5932f39d5c/test/e2e/kubectl/kubectl.go#L614-L648

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed race between container exit and stdin attach data to be processed.
```
