### PR TITLE
Re-enable critest GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,19 +246,19 @@ jobs:
           sudo chown -R $(id -u):$(id -g) ~/go/pkg/mod
           sudo chown -R $(id -u):$(id -g) ~/.cache/go-build
 
-#  test-critest:
-#    needs: release-static
-#    runs-on: ubuntu-latest
-#    timeout-minutes: 10
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v3
-#      - uses: actions/download-artifact@v3
-#        with:
-#          name: conmonrs
-#          path: target/x86_64-unknown-linux-musl/release
-#      - run: sudo cp target/x86_64-unknown-linux-musl/release/conmonrs /usr/local/bin
-#      - run: sudo chmod +x /usr/local/bin/conmonrs
-#      - run: .github/setup
-#      - name: Run critest
-#        run: sudo critest
+  test-critest:
+    needs: release-static
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: conmonrs
+          path: target/x86_64-unknown-linux-musl/release
+      - run: sudo cp target/x86_64-unknown-linux-musl/release/conmonrs /usr/local/bin
+      - run: sudo chmod +x /usr/local/bin/conmonrs
+      - run: .github/setup
+      - name: Run critest
+        run: sudo critest


### PR DESCRIPTION

#### What type of PR is this?


/kind ci

#### What this PR does / why we need it:
Re-enabling the critest if https://github.com/cri-o/cri-o/pull/6251 got merged.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
