### PR TITLE
Make version verbosity an enum

### DIFF
--- a/conmon-rs/server/src/config.rs
+++ b/conmon-rs/server/src/config.rs
@@ -12,9 +12,6 @@ macro_rules! prefix {
     };
 }
 
-/// Specifies the full version output option.
-pub const VERSION_FULL: &str = "full";
-
 #[derive(CopyGetters, Debug, Deserialize, Eq, Getters, Parser, PartialEq, Serialize, Setters)]
 #[serde(rename_all = "kebab-case")]
 #[clap(
@@ -24,17 +21,17 @@ pub const VERSION_FULL: &str = "full";
 
 /// An OCI container runtime monitor.
 pub struct Config {
-    #[get = "pub"]
+    #[get_copy = "pub"]
     #[clap(
         default_missing_value("default"),
         env(concat!(prefix!(), "VERSION")),
         long("version"),
-        possible_values(["default",  VERSION_FULL]),
+        possible_values(Verbosity::iter().map(|x| x.into()).collect::<Vec<&str>>()),
         short('v'),
         value_name("VERBOSITY")
     )]
     /// Show version information, specify "full" for verbose output.
-    version: Option<String>,
+    version: Option<Verbosity>,
 
     #[get = "pub"]
     #[clap(
@@ -110,6 +107,29 @@ pub struct Config {
     )]
     /// Select the cgroup manager to be used
     cgroup_manager: CgroupManager,
+}
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    EnumIter,
+    EnumString,
+    Eq,
+    IntoStaticStr,
+    Hash,
+    PartialEq,
+    Serialize,
+)]
+#[strum(serialize_all = "lowercase")]
+/// Available verbosity levels.
+pub enum Verbosity {
+    /// The default output verbosity.
+    Default,
+
+    /// The full output verbosity.
+    Full,
 }
 
 #[derive(

--- a/conmon-rs/server/src/server.rs
+++ b/conmon-rs/server/src/server.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     child_reaper::ChildReaper,
-    config::{CgroupManager, Config, LogDriver, VERSION_FULL},
+    config::{CgroupManager, Config, LogDriver, Verbosity},
     container_io::{ContainerIO, ContainerIOType},
     init::{DefaultInit, Init},
     listener::{DefaultListener, Listener},
@@ -54,7 +54,7 @@ impl Server {
         };
 
         if let Some(v) = server.config().version() {
-            Version::new(v == VERSION_FULL).print();
+            Version::new(v == Verbosity::Full).print();
             process::exit(0);
         }
 


### PR DESCRIPTION


#### What type of PR is this?


/kind api-change


#### What this PR does / why we need it:
This follows more idiomatic rust and makes the migration to clap v4 easier.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Removed `VERSION_FULL` in favor of the `config::Verbosity` enum.
```
