### PR TITLE
Add native types for server `LogDriver` and `LogLevel`

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -128,7 +128,7 @@ var _ = Describe("ConmonClient", func() {
 					Terminal:     terminal,
 					ExitPaths:    []string{tr.exitPath()},
 					OOMExitPaths: []string{tr.oomExitPath()},
-					LogDrivers: []client.LogDriver{{
+					LogDrivers: []client.ContainerLogDriver{{
 						Type: client.LogDriverTypeContainerRuntimeInterface,
 						Path: tr.logPath(),
 					}},
@@ -146,7 +146,7 @@ var _ = Describe("ConmonClient", func() {
 					ID:         tr.ctrID,
 					BundlePath: tr.tmpDir,
 					Terminal:   terminal,
-					LogDrivers: []client.LogDriver{{
+					LogDrivers: []client.ContainerLogDriver{{
 						Type: client.LogDriverTypeContainerRuntimeInterface,
 						Path: tr.logPath(),
 					}},

--- a/pkg/client/consts.go
+++ b/pkg/client/consts.go
@@ -1,27 +1,48 @@
 package client
 
+// LogLevel is the enum for all available server log levels.
+type LogLevel string
+
 const (
-	// LogDriverStdout is the log driver printing to stdio.
-	LogDriverStdout = "stdout"
-
-	// LogDriverSystemd is the log driver printing to systemd journald.
-	LogDriverSystemd = "systemd"
-
 	// LogLevelTrace is the log level printing only "trace" messages.
-	LogLevelTrace = "trace"
+	LogLevelTrace LogLevel = "trace"
 
 	// LogLevelDebug is the log level printing only "debug" messages.
-	LogLevelDebug = "debug"
+	LogLevelDebug LogLevel = "debug"
 
 	// LogLevelInfo is the log level printing only "info" messages.
-	LogLevelInfo = "info"
+	LogLevelInfo LogLevel = "info"
 
 	// LogLevelWarn is the log level printing only "warn" messages.
-	LogLevelWarn = "warn"
+	LogLevelWarn LogLevel = "warn"
 
 	// LogLevelError is the log level printing only "error" messages.
-	LogLevelError = "error"
+	LogLevelError LogLevel = "error"
 
 	// LogLevelOff is the log level printing no messages.
-	LogLevelOff = "off"
+	LogLevelOff LogLevel = "off"
+)
+
+// LogDriver is the enum for all available server log drivers.
+type LogDriver string
+
+const (
+	// LogDriverStdout is the log driver printing to stdio.
+	LogDriverStdout LogDriver = "stdout"
+
+	// LogDriverSystemd is the log driver printing to systemd journald.
+	LogDriverSystemd LogDriver = "systemd"
+)
+
+// CgroupManager is the enum for all available cgroup managers.
+type CgroupManager int
+
+const (
+	// CgroupManagerSystemd specifies to use systemd to create and manage
+	// cgroups.
+	CgroupManagerSystemd CgroupManager = iota
+
+	// CgroupManagerCgroupfs specifies to use the cgroup filesystem to create
+	// and manage cgroups.
+	CgroupManagerCgroupfs
 )

--- a/pkg/client/suite_test.go
+++ b/pkg/client/suite_test.go
@@ -146,7 +146,7 @@ func (tr *testRunner) defaultConfig(terminal bool) *client.CreateContainerConfig
 		Stdin:        true,
 		ExitPaths:    []string{tr.exitPath()},
 		OOMExitPaths: []string{tr.oomExitPath()},
-		LogDrivers: []client.LogDriver{{
+		LogDrivers: []client.ContainerLogDriver{{
 			Type: client.LogDriverTypeContainerRuntimeInterface,
 			Path: tr.logPath(),
 		}},


### PR DESCRIPTION


#### What type of PR is this?


/kind api-change


#### What this PR does / why we need it:
This allows a better API usage by having native types around possible values. We also now rename the LogDriver for the container creation to `ContainerLogDriver` to be more distinct compared to the server log driver.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Renamed the `LogDriver` for the container creation to `ContainerLogDriver` to be more distinct compared to the server log driver.
```
