### PR TITLE
Manually add OTEL context to both root spans

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -312,7 +312,7 @@ var _ = Describe("ConmonClient", func() {
 				rssAfter := vmRSSGivenPID(pid)
 				GinkgoWriter.Printf("VmRSS after: %d\n", rssAfter)
 				GinkgoWriter.Printf("VmRSS diff: %d\n", rssAfter-rssBefore)
-				Expect(rssAfter - rssBefore).To(BeNumerically("<", 1200))
+				Expect(rssAfter - rssBefore).To(BeNumerically("<", 1500))
 			})
 		}
 	})


### PR DESCRIPTION
#### What type of PR is this?


/kind bug

#### What this PR does / why we need it:
According to https://github.com/open-telemetry/opentelemetry-rust/issues/888#issuecomment-1280052833, this works around the issue where the root span is missing from the traces.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
