### PR TITLE
WIP: Reduce execsync memory usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ integration-static: .install.ginkgo # It needs to be release so we correctly tes
 		$(MAKE) release-static; \
 	fi && \
 	export RUNTIME_BINARY="$(RUNTIME_PATH)" && \
-	export MAX_RSS_KB=4500 && \
+	export MAX_RSS_KB=4000 && \
 	sudo -E "$(GOTOOLS_BINDIR)/ginkgo" $(TEST_FLAGS) $(GINKGO_FLAGS)
 
 .install.ginkgo:

--- a/conmon-rs/server/src/terminal.rs
+++ b/conmon-rs/server/src/terminal.rs
@@ -22,7 +22,7 @@ use tokio::{
     fs,
     io::{AsyncWriteExt, Interest},
     net::UnixStream,
-    sync::mpsc::{self, Receiver, Sender, UnboundedReceiver},
+    sync::mpsc::{self, Receiver, Sender},
     task,
 };
 use tokio_fd::AsyncFd;
@@ -37,7 +37,7 @@ pub struct Terminal {
     connected_rx: Receiver<RawFd>,
 
     #[getset(get = "pub", get_mut = "pub")]
-    message_rx: Option<UnboundedReceiver<Message>>,
+    message_rx: Option<Receiver<Message>>,
 
     #[getset(get, set)]
     tty: Option<RawFd>,
@@ -113,7 +113,7 @@ impl Terminal {
 
         let attach_clone = self.attach.clone();
         let logger_clone = self.logger.clone();
-        let (message_tx, message_rx) = mpsc::unbounded_channel();
+        let (message_tx, message_rx) = ContainerIO::message_channel();
         self.message_rx = Some(message_rx);
 
         task::spawn(

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -312,7 +312,7 @@ var _ = Describe("ConmonClient", func() {
 				rssAfter := vmRSSGivenPID(pid)
 				GinkgoWriter.Printf("VmRSS after: %d\n", rssAfter)
 				GinkgoWriter.Printf("VmRSS diff: %d\n", rssAfter-rssBefore)
-				Expect(rssAfter - rssBefore).To(BeNumerically("<", 1500))
+				Expect(rssAfter - rssBefore).To(BeNumerically("<", 200))
 			})
 		}
 	})

--- a/pkg/client/suite_test.go
+++ b/pkg/client/suite_test.go
@@ -38,7 +38,7 @@ var (
 	busyboxDest = filepath.Join(busyboxDestDir, "busybox")
 	runtimePath = os.Getenv("RUNTIME_BINARY")
 	conmonPath  = os.Getenv(conmonBinaryKey)
-	maxRSSKB    = 4500
+	maxRSSKB    = 4000
 )
 
 // TestConmonClient runs the created specs.


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Trying to reduce the memory usage by bounding the channels and closing them after usage.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
