### PR TITLE
Use `stable` toolchain for static build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,10 @@ jobs:
       - name: Select Toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env['ACTION_MSRV_TOOLCHAIN']  }}
+          # Ubuntu 22.04 glibc static is not compatible with rustc 1.58.1 (see
+          # ACTION_MSRV_TOOLCHAIN). Means we now just use the latest one, since
+          # the static builds are made for the community.
+          toolchain: stable
           default: true
           override: true
           components: rustfmt


### PR DESCRIPTION
#### What type of PR is this?


/kind failing-test

#### What this PR does / why we need it:

Ubuntu 22.04 glibc static is not compatible with rustc 1.58.1 (see `ACTION_MSRV_TOOLCHAIN`). Means we now just use the latest one, since the static builds are made for the community.

#### Which issue(s) this PR fixes:

Fixes #957

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Switched to latest rust stable for static binaries.
```
