### PR TITLE
Drain stdin on attach

### DIFF
--- a/conmon-rs/server/src/attach.rs
+++ b/conmon-rs/server/src/attach.rs
@@ -90,13 +90,6 @@ impl SharedContainerAttach {
             .context("receive attach message")
     }
 
-    /// Try to read from all attach endpoints standard input and return the first result.
-    pub fn try_read(&mut self) -> Result<Vec<u8>> {
-        self.read_half_rx
-            .try_recv()
-            .context("try to receive attach message")
-    }
-
     /// Write a buffer to all attach endpoints.
     pub async fn write(&mut self, m: Message) -> Result<()> {
         if self.write_half_tx.receiver_count() > 0 {

--- a/conmon-rs/server/src/container_io.rs
+++ b/conmon-rs/server/src/container_io.rs
@@ -335,11 +335,11 @@ impl ContainerIO {
                     }
                 }
                 _ = token.cancelled() => {
-                    // Closing immediately may race with outstanding data on stdin for short lived
-                    // containers. This means we try to read once again.
-                    if let Ok(data) = attach.try_read() {
+                    debug!("Token cancelled, draining stdin");
+                    if let Ok(data) = attach.read().await {
                         Self::handle_stdin_data(&data, &mut writer).await?;
                     }
+
                     return Ok(());
                 }
             }


### PR DESCRIPTION
#### What type of PR is this?


/kind failing-test


#### What this PR does / why we need it:
The Kubernetes e2e test flakes because of a token cancellation race between stdin and attach read:

```
[FAIL] [sig-cli] Kubectl client Simple pod [It] should support inline execution and attach
…
  << Timeline

  [FAILED] Expected
      <string>: read:stdin closed

  to contain substring
      <string>: read:value
  In [It] at: test/e2e/kubectl/kubectl.go:764 @ 01/04/23 15:09:48.618
```
https://github.com/kubernetes/kubernetes/blob/5cbd6960c805c22e1c741dde3ce9f2e10f869bce/test/e2e/kubectl/kubectl.go#L757-L766

The issue is that we cancel the token immediately which stops reading from attach. But the container command `echo -n read: && cat && echo 'stdin closed'` within the test provides additional data, which gets no time to be delivered.

We now drain stdin accordingly and wait for all data to be passed down to the receiver.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://github.com/containers/conmon-rs/issues/736
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Correctly drain stdin on attach.
```
