### PR TITLE
Revert "Drain stdin on attach"

### DIFF
--- a/conmon-rs/server/src/attach.rs
+++ b/conmon-rs/server/src/attach.rs
@@ -90,6 +90,13 @@ impl SharedContainerAttach {
             .context("receive attach message")
     }
 
+    /// Try to read from all attach endpoints standard input and return the first result.
+    pub fn try_read(&mut self) -> Result<Vec<u8>> {
+        self.read_half_rx
+            .try_recv()
+            .context("try to receive attach message")
+    }
+
     /// Write a buffer to all attach endpoints.
     pub async fn write(&mut self, m: Message) -> Result<()> {
         if self.write_half_tx.receiver_count() > 0 {

--- a/conmon-rs/server/src/container_io.rs
+++ b/conmon-rs/server/src/container_io.rs
@@ -335,11 +335,11 @@ impl ContainerIO {
                     }
                 }
                 _ = token.cancelled() => {
-                    debug!("Token cancelled, draining stdin");
-                    if let Ok(data) = attach.read().await {
+                    // Closing immediately may race with outstanding data on stdin for short lived
+                    // containers. This means we try to read once again.
+                    if let Ok(data) = attach.try_read() {
                         Self::handle_stdin_data(&data, &mut writer).await?;
                     }
-
                     return Ok(());
                 }
             }


### PR DESCRIPTION
Reverts containers/conmon-rs#991

This will not fix the problem and will make it even worse. We have to somehow split-up the cancellation tokens to wait for stdin and stdout/err separately. 