### PR TITLE
Fix OOM watcher for cgroupv2 `oom_kill` events

### DIFF
--- a/conmon-rs/server/src/child_reaper.rs
+++ b/conmon-rs/server/src/child_reaper.rs
@@ -395,7 +395,7 @@ impl ReapableChild {
                     return exit_code;
                 }
                 Ok(WaitStatus::Signaled(_, sig, _)) => {
-                    debug!("Signaled");
+                    debug!("Signaled: {sig}");
                     token.cancel();
                     return (sig as i32) + 128;
                 }


### PR DESCRIPTION


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
It may be possible that the container process already got signaled but is still running, whereas we will not get a `modify` (but `other`) event on the file watcher. Beside that, it will also not update the `oom` entry of `memory.events`, but the `oom_kill`, which provides another indicator for a possible out of memory kill.

Ref: https://www.kernel.org/doc/Documentation/cgroup-v2.txt

#### Which issue(s) this PR fixes:

Adresses https://github.com/cri-o/cri-o/issues/6580 for the conmon-rs usage 

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed OOM detection for cgroup v2 edge-cases where the container already got signaled but has not been fully OOM killed.
```
