### PR TITLE
Bind missing namespaces to host

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -553,11 +553,12 @@ var _ = Describe("ConmonClient", func() {
 			Expect(err).To(BeNil())
 			Expect(response).NotTo(BeNil())
 
-			Expect(len(response.Namespaces)).To(BeEquivalentTo(4))
+			Expect(len(response.Namespaces)).To(BeEquivalentTo(5))
 			Expect(response.Namespaces[0].Type).To(Equal(client.NamespaceIPC))
-			Expect(response.Namespaces[1].Type).To(Equal(client.NamespaceNet))
-			Expect(response.Namespaces[2].Type).To(Equal(client.NamespacePID))
-			Expect(response.Namespaces[3].Type).To(Equal(client.NamespaceUTS))
+			Expect(response.Namespaces[1].Type).To(Equal(client.NamespacePID))
+			Expect(response.Namespaces[2].Type).To(Equal(client.NamespaceNet))
+			Expect(response.Namespaces[3].Type).To(Equal(client.NamespaceUser))
+			Expect(response.Namespaces[4].Type).To(Equal(client.NamespaceUTS))
 
 			for _, ns := range response.Namespaces {
 				stat, err := os.Lstat(ns.Path)
@@ -565,7 +566,6 @@ var _ = Describe("ConmonClient", func() {
 				Expect(stat.IsDir()).To(BeFalse())
 				Expect(stat.Size()).To(BeZero())
 				Expect(stat.Mode()).To(Equal(fs.FileMode(0o444)))
-				Expect(len(stat.Name())).To(BeEquivalentTo(3))
 			}
 		})
 
@@ -594,12 +594,11 @@ var _ = Describe("ConmonClient", func() {
 			Expect(response).NotTo(BeNil())
 
 			Expect(len(response.Namespaces)).To(BeEquivalentTo(5))
-
 			Expect(response.Namespaces[0].Type).To(Equal(client.NamespaceIPC))
-			Expect(response.Namespaces[1].Type).To(Equal(client.NamespaceNet))
-			Expect(response.Namespaces[2].Type).To(Equal(client.NamespacePID))
-			Expect(response.Namespaces[3].Type).To(Equal(client.NamespaceUTS))
-			Expect(response.Namespaces[4].Type).To(Equal(client.NamespaceUser))
+			Expect(response.Namespaces[1].Type).To(Equal(client.NamespacePID))
+			Expect(response.Namespaces[2].Type).To(Equal(client.NamespaceNet))
+			Expect(response.Namespaces[3].Type).To(Equal(client.NamespaceUser))
+			Expect(response.Namespaces[4].Type).To(Equal(client.NamespaceUTS))
 
 			for _, ns := range response.Namespaces {
 				stat, err := os.Lstat(ns.Path)


### PR DESCRIPTION


#### What type of PR is this?


/kind bug

#### What this PR does / why we need it:
We now bind all namespaces, independently if unshared or not. If a namespace is not being unshared, then we fallback to the host.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Required for https://github.com/cri-o/cri-o/pull/6590
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed pinning all namespaces to the host when not selected for unsharing in `conmonrs pause`
```
