### PR TITLE
Use zeitgeist for dependency verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
           components: rustfmt
       - run: cargo build
 
+  dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - run: make verify-dependencies
+
   go-lint:
     runs-on: ubuntu-latest
     steps:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,0 +1,49 @@
+---
+dependencies:
+  - name: go
+    version: 1.19
+    refPaths:
+      - path: .github/workflows/ci.yml
+        match: GO_VERSION
+      - path: .github/workflows/release.yml
+        match: GO_VERSION
+
+  - name: rust
+    version: 1.58.1
+    refPaths:
+      - path: .github/workflows/ci.yml
+        match: ACTION_MSRV_TOOLCHAIN
+      - path: .github/workflows/release.yml
+        match: ACTION_MSRV_TOOLCHAIN
+
+  - name: golangci-lint
+    version: 1.50.1
+    refPaths:
+      - path: .github/workflows/ci.yml
+        match: version
+      - path: Makefile
+        match: GOLANGCI_LINT_VERSION
+
+  - name: ginkgo
+    version: 2.8.0
+    refPaths:
+      - path: Makefile
+        match: GINKGO_VERSION
+
+  - name: zeitgeist
+    version: 0.3.5
+    refPaths:
+      - path: Makefile
+        match: ZEITGEIST_VERSION
+
+  - name: jaeger
+    version: 1.41.0
+    refPaths:
+      - path: contrib/tracing/start
+        match: JAEGER_IMG
+
+  - name: opentelemetry-collector
+    version: 0.70.0
+    refPaths:
+      - path: contrib/tracing/start
+        match: OTLP_IMG


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

We now use a dedicated job for verifying our dependencies while pinning them in `dependencies.yaml`.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```
