### PR TITLE
Add dedicated error if no PID namespace should be unshared

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -100,16 +100,16 @@ linters:
     # - wsl
 linters-settings:
   funlen:
-    lines: 155
+    lines: 200
     statements: 50
   varnamelen:
     min-name-length: 1
   cyclop:
-    max-complexity: 35
+    max-complexity: 40
   gocognit:
-    min-complexity: 50
+    min-complexity: 55
   gocyclo:
-    min-complexity: 50
+    min-complexity: 55
   nestif:
     min-complexity: 15
   errcheck:

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1074,6 +1074,20 @@ func (c *ConmonClient) CreateNamespaces(
 		return nil, fmt.Errorf("requires at least %v: %w", minVersion, ErrUnsupported)
 	}
 
+	// The pause process is only required if a PID namespace should be unshared.
+	foundPIDNamespace := false
+	for _, ns := range cfg.Namespaces {
+		if ns == NamespacePID {
+			foundPIDNamespace = true
+
+			break
+		}
+	}
+
+	if !foundPIDNamespace {
+		return nil, ErrNoPIDNamespaceSpecified
+	}
+
 	conn, err := c.newRPCConn()
 	if err != nil {
 		return nil, fmt.Errorf("create RPC connection: %w", err)

--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -9,4 +9,8 @@ var (
 
 	// ErrUnsupported gets returned if the server does not the feature.
 	ErrUnsupported = errors.New("feature not supported by this conmon-rs version")
+
+	// ErrNoPIDNamespaceSpecified gets returned if no PID namespace should be
+	// unshared via the CreateaNamespacesConfig in the CreateNamespaces method.
+	ErrNoPIDNamespaceSpecified = errors.New("no PID namespace specified")
 )


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup

#### What this PR does / why we need it:
We do not have to create the pause process on `CreateNamespaces` if no PID namespace should be unshared. In this case we now return a dedicated error and let the users decide what to do with it.



#### Which issue(s) this PR fixes:

Fixes https://github.com/containers/conmon-rs/issues/1066

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Return `ErrNoPIDNamespaceSpecified` if no PID namespace should be unshared in the `CreateNamespaces` method.
```
