### PR TITLE
[CI:BUILD] Packit: initial enablement

### DIFF
--- a/.packit.sh
+++ b/.packit.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Packit's default fix-spec-file often doesn't fetch version string correctly.
+# This script handles any custom processing of the dist-git spec file and gets used by the
+# fix-spec-file action in .packit.yaml
+
+set -eo pipefail
+
+# Get Version from HEAD
+HEAD_VERSION=$(grep '^version' conmon-rs/common/Cargo.toml | cut -d\" -f2 | sed -e 's/-/~/')
+
+# Generate source tarball from HEAD
+git archive --prefix=conmon-rs-$HEAD_VERSION/ -o conmon-rs-$HEAD_VERSION.tar.gz HEAD
+
+# RPM Spec modifications
+
+# Update Version in spec with Version from Cargo.toml
+sed -i "s/^Version:.*/Version: $HEAD_VERSION/" conmon-rs.spec
+
+# Update Release in spec with Packit's release envvar
+sed -i "s/^Release: %autorelease/Release: $PACKIT_RPMSPEC_RELEASE%{?dist}/" conmon-rs.spec
+
+# Update Source tarball name in spec
+sed -i "s/^Source:.*.tar.gz/Source: %{name}-$HEAD_VERSION.tar.gz/" conmon-rs.spec
+
+# Update setup macro to use the correct build dir
+sed -i "s/^%setup.*/%autosetup -Sgit -n %{name}-$HEAD_VERSION/" conmon-rs.spec

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,24 @@
+---
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+# Build targets can be found at:
+# https://copr.fedorainfracloud.org/coprs/rhcontainerbot/packit-builds/
+
+specfile_path: conmon-rs.spec
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    owner: rhcontainerbot
+    project: packit-builds
+    enable_net: true
+    srpm_build_deps:
+      - cargo
+      - make
+      - rpkg
+    actions:
+      post-upstream-clone:
+        - "rpkg spec --outdir ./"
+      fix-spec-file:
+        - "bash .packit.sh"

--- a/conmon-rs.spec.rpkg
+++ b/conmon-rs.spec.rpkg
@@ -24,6 +24,8 @@ License: ASL 2.0 and BSD and ISC and MIT
 URL: https://github.com/containers/conmon-rs
 VCS: {{{ git_dir_vcs }}}
 Source: {{{ git_dir_pack }}}
+# CentOS Stream doesn't have capnproto yet.
+# It's built separately on the copr
 BuildRequires: capnproto
 BuildRequires: cargo
 BuildRequires: git-core

--- a/conmon-rs/common/Cargo.toml
+++ b/conmon-rs/common/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "conmon-common"
+# Version listed below is also used by .packit.sh
 version = "0.5.0"
 edition = "2018"
 


### PR DESCRIPTION
This commit will run COPR builds on every PR against all active releases of CentOS Stream and Fedora, thus allowing buildability checks before the PR merges.

Builds are done on a custom COPR project:
`rhcontainerbot/packit-builds`.
Ref: https://copr.fedorainfracloud.org/coprs/rhcontainerbot/packit-builds/

The build targets are set in the copr itself, so we don't need to explicitly mention them in `.packit.yaml`, making upstream configuration a lot simpler.

The `spec.rpkg` file meant for rpm builds post-pr-merge at `rhcontainerbot/podman-next` copr gets reused for packit builds, so the packit jobs are independent of Fedora / CentOS dist-git.

Fixes: #1103

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/containers/conmon-rs/blob/main/CONTRIBUTING.md) as well as
ensuring that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind ci

#### What this PR does / why we need it:

Checks for fedora and centos stream buildability pre-merge.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


Fixes #1103 

#### Special notes for your reviewer:

None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
