### PR TITLE
Reference `podman-next` project for `main` packit builds

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -27,3 +27,4 @@ jobs:
   - <<: *copr
     trigger: commit
     branch: main
+    project: podman-next


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
Refering to https://github.com/containers/conmon-rs/pull/1108#issuecomment-1429890874 and https://github.com/containers/conmon-rs/pull/1108#issuecomment-1429862459, we now reference the project `podman-next` when building packages for `main`.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
