### PR TITLE
Use default umask `0022`

### DIFF
--- a/conmon-rs/server/src/server.rs
+++ b/conmon-rs/server/src/server.rs
@@ -136,6 +136,7 @@ impl Server {
     fn init() -> Result<()> {
         let init = Init::<DefaultInit>::default();
         init.unset_locale()?;
+        init.set_default_umask();
         // While we could configure this, standard practice has it as -1000,
         // so it may be YAGNI to add configuration.
         init.set_oom_score("-1000")


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:

Under non-reproducible circumstances it can happen that the umask of conmon-rs is set to 0000, which can be a security issue. To avoid that, we now use a default umask and set it directly in the init module.

We had a similar fix in CRI-O in cri-o/cri-o#5904, but we have to do it here again because conmon-rs is a direct parent of PID 1.

#### Which issue(s) this PR fixes:

Refers to https://issues.redhat.com/browse/OCPBUGS-8057

#### Special notes for your reviewer:

Proposing the same in conmon: https://github.com/containers/conmon/pull/388
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Using default umask of `0022` for all conmon-rs processes.
```
