### PR TITLE
Fix signing binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
         if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags')
         run: |
           cd ${{ github.sha }}
-          cosign sign-blob conmonrs \
+          cosign sign-blob -y conmonrs \
             --output-signature conmonrs.sig \
             --output-certificate conmonrs.cert
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION


#### What type of PR is this?


/kind failing-test

#### What this PR does / why we need it:
It looks like that we can pass `-y` to omit the prompt in the CI script.

#### Which issue(s) this PR fixes:

See https://github.com/containers/conmon-rs/actions/runs/4342656226/jobs/7583748919

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
