### PR TITLE
Packit: Fix sed for release tag update in rpm spec

### DIFF
--- a/.packit.sh
+++ b/.packit.sh
@@ -19,7 +19,7 @@ git archive --prefix=conmon-rs-$HEAD_VERSION/ -o conmon-rs-$HEAD_VERSION.tar.gz 
 sed -i "s/^Version:.*/Version: $HEAD_VERSION/" conmon-rs.spec
 
 # Update Release in spec with Packit's release envvar
-sed -i "s/^Release: %autorelease/Release: $PACKIT_RPMSPEC_RELEASE%{?dist}/" conmon-rs.spec
+sed -i "s/^Release:.*/Release: $PACKIT_RPMSPEC_RELEASE%{?dist}/" conmon-rs.spec
 
 # Update Source tarball name in spec
 sed -i "s/^Source:.*.tar.gz/Source: %{name}-$HEAD_VERSION.tar.gz/" conmon-rs.spec


### PR DESCRIPTION
Resolves: #1173

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/containers/conmon-rs/blob/main/CONTRIBUTING.md) as well as
ensuring that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->


/kind other


#### What this PR does / why we need it:
Fixes rpm release tag in copr builds

#### Which issue(s) this PR fixes:
#1173 

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


Fixes #1173 

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
