### PR TITLE
Fix get script blob verification

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -72,13 +72,13 @@ download_binary() {
             curl_retry "$BASE_URL/$COMMIT/$FILE" -o "$FILE"
         done
 
-        ORG=${GITHUB_ACTOR:-containers}
+        SLUG=containers/conmon-rs
         GIT_REF=refs/heads/main
         cosign verify-blob conmonrs \
-            --certificate-identity "https://github.com/$ORG/conmon-rs/.github/workflows/ci.yml@$GIT_REF" \
+            --certificate-identity "https://github.com/$SLUG/.github/workflows/ci.yml@$GIT_REF" \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             --certificate-github-workflow-name ci \
-            --certificate-github-workflow-repository "$ORG/conmon-rs" \
+            --certificate-github-workflow-repository "$SLUG" \
             --certificate-github-workflow-ref $GIT_REF \
             --signature conmonrs.sig \
             --certificate conmonrs.cert


### PR DESCRIPTION

#### What type of PR is this?


/kind failing-test

#### What this PR does / why we need it:
Fixing the get-script CI. Taking the `GITHUB_ACTOR` into account is just not right, it should be always `containers/conmon-rs`.
#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?


```release-note
None
```
