### PR TITLE
Use cri-tools `master` branch

### DIFF
--- a/.github/setup
+++ b/.github/setup
@@ -60,9 +60,14 @@ EOT
 }
 
 install_critest() {
-    TAG=v1.25.0
-    curl_retry "https://storage.googleapis.com/k8s-artifacts-cri-tools/release/$TAG/critest-$TAG-linux-amd64.tar.gz" |
-        sudo tar xfz - -C /usr/local/bin
+    URL=https://github.com/kubernetes-sigs/cri-tools
+
+    git clone $URL
+    pushd cri-tools
+    sudo -E PATH="$PATH" make BINDIR=/usr/local/bin install
+    popd
+    sudo rm -rf cri-tools
+    sudo critest --version
 }
 
 main "$@"


### PR DESCRIPTION


#### What type of PR is this?


/kind failing-test


#### What this PR does / why we need it:
The cri-tools suite is failing because we removed the seccomp tests in upstream CRI-O. This should be fixed by using the latest critest from `master`.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
