### PR TITLE
Mention that the go client reuses a running server

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -153,6 +153,11 @@ func FromLogrusLevel(level logrus.Level) LogLevel {
 }
 
 // New creates a new conmon server, starts it and connects a new client to it.
+//
+// If a server is already started with the same `ServerRunDir` specified
+// the client connects to the existing server instead.
+// Note: Other options from the `ConmonServerConfig` will be ignored
+// and the settings of the existing server will remain unchanged.
 func New(config *ConmonServerConfig) (client *ConmonClient, retErr error) {
 	cl, err := config.toClient()
 	if err != nil {


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Mention in the documentation that the go client will connect to an already running server instance.

When a server is already listening in the same `ServerRunDir`, the client reuses that server.

That also means that other options of the `ConmonServerConfig` will be ignored. The server will keep its settings from the first invocation.

#### Does this PR introduce a user-facing change?

```release-note
None
```
