### PR TITLE
Remove redundant serialization of OOMExitPaths

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -702,9 +702,6 @@ func (c *ConmonClient) CreateContainer(
 		if err := stringSliceToTextList(cfg.OOMExitPaths, req.NewOomExitPaths); err != nil {
 			return fmt.Errorf("convert oom exit paths string slice to text list: %w", err)
 		}
-		if err := stringSliceToTextList(cfg.OOMExitPaths, req.NewOomExitPaths); err != nil {
-			return err
-		}
 
 		if err := c.initLogDrivers(&req, cfg.LogDrivers); err != nil {
 			return fmt.Errorf("init log drivers: %w", err)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Merging of 22a1616 and c354aaf resulted in redundant serialization of the `OOMExitPaths` field.

#### Special notes for your reviewer:

Both commits introduced the `OOMExitPaths` field and added serialization code.

#### Does this PR introduce a user-facing change?

```release-note
None
```
