### PR TITLE
Remove unnecessary SetRequest calls

### DIFF
--- a/pkg/client/attach.go
+++ b/pkg/client/attach.go
@@ -499,10 +499,6 @@ func (c *ConmonClient) SetWindowSizeContainer(ctx context.Context, cfg *SetWindo
 		req.SetWidth(cfg.Size.Width)
 		req.SetHeight(cfg.Size.Height)
 
-		if err := p.SetRequest(req); err != nil {
-			return fmt.Errorf("set request: %w", err)
-		}
-
 		return nil
 	})
 	defer free()

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -724,10 +724,6 @@ func (c *ConmonClient) CreateContainer(
 			return fmt.Errorf("convert cleanup command string slice to text list: %w", err)
 		}
 
-		if err := p.SetRequest(req); err != nil {
-			return fmt.Errorf("set request: %w", err)
-		}
-
 		return nil
 	})
 	defer free()
@@ -813,9 +809,6 @@ func (c *ConmonClient) ExecSyncContainer(ctx context.Context, cfg *ExecSyncConfi
 			return err
 		}
 		req.SetTerminal(cfg.Terminal)
-		if err := p.SetRequest(req); err != nil {
-			return fmt.Errorf("set request: %w", err)
-		}
 
 		return nil
 	})
@@ -978,10 +971,6 @@ func (c *ConmonClient) ReopenLogContainer(ctx context.Context, cfg *ReopenLogCon
 
 		if err := req.SetId(cfg.ID); err != nil {
 			return fmt.Errorf("set ID: %w", err)
-		}
-
-		if err := p.SetRequest(req); err != nil {
-			return fmt.Errorf("set request: %w", err)
 		}
 
 		return nil


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
A capnp request created with `p.NewRequest()` is already associated with the params.

Therefore a call to `p.SetRequest(req)` is not necessary.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
The `SetRequest` function was only used in 4 out of 7 requests. The others already work without this call.

#### Does this PR introduce a user-facing change?

```release-note
None
```
