### PR TITLE
Fix clippy lint

### DIFF
--- a/conmon-rs/server/src/container_io.rs
+++ b/conmon-rs/server/src/container_io.rs
@@ -243,7 +243,7 @@ impl ContainerIO {
 
         loop {
             match reader.read(&mut buf).await {
-                Ok(n) if n == 0 => {
+                Ok(0) => {
                     debug!("Nothing more to read");
 
                     attach


### PR DESCRIPTION


#### What type of PR is this?


/kind failing-test

#### What this PR does / why we need it:
This fixes the redundant guard error:

```
error: redundant guard
   --> conmon-rs/server/src/container_io.rs:246:26
    |
246 |                 Ok(n) if n == 0 => {
    |                          ^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_guards
    = note: `-D clippy::redundant-guards` implied by `-D warnings`
help: try
    |
246 -                 Ok(n) if n == 0 => {
246 +                 Ok(0) => {
    |
```

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
