### PR TITLE
packit: Build PRs into default packit COPRs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -2,46 +2,41 @@
 # See the documentation for more information:
 # https://packit.dev/docs/configuration/
 
-# Pull request build targets can be found at:
-# https://copr.fedorainfracloud.org/coprs/rhcontainerbot/packit-builds/
-
 # Main branch commit build targets can be found at:
 # https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next/
 
 specfile_path: conmon-rs.spec
 
-jobs:
-  - &copr
-    job: copr_build
-    trigger: pull_request
-    owner: rhcontainerbot
-    project: packit-builds
-    enable_net: true
-    srpm_build_deps:
-      - cargo
-      - make
-      - rpkg
-    targets:
-      - centos-stream-8-aarch64
-      - centos-stream-8-x86_64
-      - centos-stream-9-aarch64
-      - centos-stream-9-x86_64
-      - fedora-all-aarch64
-      - fedora-all-x86_64
-    actions:
-      post-upstream-clone:
-        - "rpkg spec --outdir ./"
-      fix-spec-file:
-        - "bash .packit.sh"
+srpm_build_deps:
+  - cargo
+  - make
+  - rpkg
 
-  - <<: *copr
+actions:
+  post-upstream-clone:
+    - "rpkg spec --outdir ./"
+  fix-spec-file:
+    - "bash .packit.sh"
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    # keep in sync with https://copr.fedorainfracloud.org/coprs/rhcontainerbot/podman-next
+    enable_net: true
+    targets:
+      - fedora-all-x86_64
+      - fedora-all-aarch64
+      - centos-stream+epel-next-8-x86_64
+      - centos-stream+epel-next-8-aarch64
+      - centos-stream+epel-next-9-x86_64
+      - centos-stream+epel-next-9-aarch64
+    additional_repos:
+      - "copr://rhcontainerbot/podman-next"
+
+  # Run on commit to main branch
+  - job: copr_build
     trigger: commit
     branch: main
+    owner: rhcontainerbot
     project: podman-next
-    targets:
-      - centos-stream+epel-next-8-aarch64
-      - centos-stream+epel-next-8-x86_64
-      - centos-stream+epel-next-9-aarch64
-      - centos-stream+epel-next-9-x86_64
-      - fedora-all-aarch64
-      - fedora-all-x86_64
+    enable_net: true


### PR DESCRIPTION
Building all PRs of all container projects into the same COPR does not properly isolate PRs from each other.

To avoid that, change the copr_build configuration to use the packit default COPRs, which are specific to the particular PR, and disappear after a few weeks. Depending projects should only run against what landed in conmon-rs/main i.e. the podman-next COPR.

#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:

This is exactly the same as https://github.com/containers/crun/pull/1260 ; please see the discussion there, this change needs to be applied to all container projects, and then all land together. Let's keep all the relevant discussions and tracking in  the crun PR please.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Discussed with @lsm5 in https://github.com/containers/crun/pull/1260

#### Does this PR introduce a user-facing change?

```release-note
None
```
