### PR TITLE
Bump Rust to v1.69.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   GO_VERSION: '1.20'
-  ACTION_MSRV_TOOLCHAIN: 1.66.1
+  ACTION_MSRV_TOOLCHAIN: 1.69.0
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   GO_VERSION: '1.20'
-  ACTION_MSRV_TOOLCHAIN: 1.66.1
+  ACTION_MSRV_TOOLCHAIN: 1.69.0
 
 jobs:
   build:

--- a/conmon-rs/server/Cargo.toml
+++ b/conmon-rs/server/Cargo.toml
@@ -30,7 +30,7 @@ prctl = "1.0.0"
 regex = "1.9.3"
 sendfd = { version = "0.4.3", features = ["tokio"] }
 serde = { version = "1.0.183", features = ["derive"] }
-shadow-rs = "=0.23.0"
+shadow-rs = "0.23.0"
 signal-hook = "0.3.17"
 strum = { version = "0.25.0", features = ["derive"] }
 tempfile = "3.7.1"
@@ -45,9 +45,9 @@ tz-rs = "0.6.14"
 uuid = { version = "1.4.1", features = ["v4", "fast-rng", "macro-diagnostics"] }
 
 [build-dependencies]
-shadow-rs = "=0.23.0"
-dashmap = "=5.5.0"
+shadow-rs = "0.23.0"
+dashmap = "5.5.0"
 
 [dev-dependencies]
 mockall = "0.11.4"
-time = { version = "=0.3.23", features = ["parsing"] }
+time = { version = "0.3.23", features = ["parsing"] }

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -9,7 +9,7 @@ dependencies:
         match: GO_VERSION
 
   - name: rust
-    version: 1.66.1
+    version: 1.69.0
     refPaths:
       - path: .github/workflows/ci.yml
         match: ACTION_MSRV_TOOLCHAIN


### PR DESCRIPTION


#### What type of PR is this?


/kind ci

#### What this PR does / why we need it:
We can also remove the build constraints from the `Cargo.toml` file since we have updated them in the past.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Updated latest required Rust version to v1.69.0
```
