### PR TITLE
Add opentelemetry dependency group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,11 @@ updates:
   allow:
   - dependency-type: direct
   - dependency-type: indirect
+  groups:
+    opentelemetry:
+      patterns:
+        - "opentelemetry*"
+        - "tracing-opentelemetry"
 - package-ecosystem: gomod
   directory: "/"
   schedule:


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
This allows dependabot to group dependency updates, which were required to be manually in PR's like https://github.com/containers/conmon-rs/pull/1551.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
