### PR TITLE
Add automatic shutdown after inactivity

### DIFF
--- a/conmon-rs/server/src/config.rs
+++ b/conmon-rs/server/src/config.rs
@@ -12,7 +12,7 @@ macro_rules! prefix {
     };
 }
 
-#[derive(CopyGetters, Debug, Deserialize, Eq, Getters, Parser, PartialEq, Serialize, Setters)]
+#[derive(CopyGetters, Debug, Deserialize, Getters, Parser, PartialEq, Serialize, Setters)]
 #[serde(rename_all = "kebab-case")]
 #[command(
     after_help("More info at: https://github.com/containers/conmon-rs"),
@@ -125,6 +125,16 @@ pub struct Config {
     )]
     /// OpenTelemetry GRPC endpoint to be used for tracing.
     tracing_endpoint: String,
+
+    #[get_copy = "pub"]
+    #[arg(
+        default_value_t,
+        env(concat!(prefix!(), "SHUTDOWN_DELAY")),
+        long("shutdown-delay"),
+        value_name("DELAY"),
+    )]
+    /// Automatically stop conmon-rs after DELAY seconds of inactivity. (0 = disabled)
+    shutdown_delay: f64,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize, Subcommand)]

--- a/conmon-rs/server/src/inactivity.rs
+++ b/conmon-rs/server/src/inactivity.rs
@@ -1,0 +1,128 @@
+use std::{
+    future, process,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use tokio::sync::{futures::Notified, Notify};
+
+/// Track activity and reacto to inactivity.
+///
+/// Can be used to exit accept loops after inactivity.
+#[derive(Debug, Clone)]
+pub struct Inactivity(Option<Arc<Inner>>);
+
+impl Inactivity {
+    /// Create a new inactivity tracker.
+    pub fn new() -> Self {
+        Self(Some(Arc::default()))
+    }
+
+    /// Create a disabled inactivity tracker.
+    ///
+    /// The wait function will never return. There is always activity.
+    pub const fn disabled() -> Self {
+        Self(None)
+    }
+
+    /// Start tracking an activity.
+    pub fn activity(&self) -> Activity {
+        Activity::new(self.0.as_ref())
+    }
+
+    /// Async "block" until there is no activity and then wait for an additional`timeout`.
+    pub async fn wait(&self, timeout: Duration) {
+        if let Some(inner) = &self.0 {
+            loop {
+                let changed = inner.changed();
+                if inner.no_activity() {
+                    let _ = tokio::time::timeout(timeout, changed).await;
+                    if inner.no_activity() {
+                        break;
+                    }
+                } else {
+                    changed.await
+                }
+            }
+        } else {
+            future::pending().await
+        }
+    }
+}
+
+/// Track an activity. Can be cloned to track additional activities.
+///
+/// The Activity stops on drop.
+#[derive(Debug)]
+pub struct Activity(Option<Arc<Inner>>);
+
+impl Activity {
+    fn new(inner: Option<&Arc<Inner>>) -> Self {
+        Self(inner.map(Inner::increment))
+    }
+
+    /// Explicitly stop an activity. Just a wrapper for `drop(activity)`.
+    pub fn stop(self) {
+        // nothing to to, we take self by value
+    }
+}
+
+impl Clone for Activity {
+    fn clone(&self) -> Self {
+        Self::new(self.0.as_ref())
+    }
+}
+
+impl Drop for Activity {
+    fn drop(&mut self) {
+        if let Some(inner) = &self.0 {
+            inner.decrement();
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct Inner {
+    // number of current activities
+    active: AtomicUsize,
+    // gets notofied whenever the result of `no_activity` changes
+    notify: Notify,
+}
+
+impl Inner {
+    /// Abort if more then isize::MAX activities are active.
+    ///
+    /// This prevents integer overflow of the `active` counter in case
+    /// someone is `mem::forget`ing activities.
+    ///
+    /// The same logic is applied internally by the `Arc` implementation.
+    const MAX_ACTIVE: usize = isize::MAX as usize;
+
+    fn increment(self: &Arc<Self>) -> Arc<Self> {
+        match self.active.fetch_add(1, Ordering::Relaxed) {
+            0 => self.notify.notify_waiters(),
+            1..=Self::MAX_ACTIVE => {}
+            _ => process::abort(),
+        }
+        self.clone()
+    }
+
+    fn decrement(&self) {
+        match self.active.fetch_sub(1, Ordering::Relaxed) {
+            1 => self.notify.notify_waiters(),
+            2..=Self::MAX_ACTIVE => {}
+            _ => process::abort(),
+        }
+    }
+
+    fn no_activity(&self) -> bool {
+        self.active.load(Ordering::Relaxed) == 0
+    }
+
+    fn changed(&self) -> Notified {
+        self.notify.notified()
+    }
+}

--- a/conmon-rs/server/src/lib.rs
+++ b/conmon-rs/server/src/lib.rs
@@ -16,6 +16,7 @@ mod container_io;
 mod container_log;
 mod cri_logger;
 mod fd_socket;
+mod inactivity;
 mod init;
 mod journal;
 mod listener;

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -95,6 +95,11 @@ type ConmonServerConfig struct {
 
 	// Tracing can be used to enable OpenTelemetry tracing.
 	Tracing *Tracing
+
+	// ShutdownDelay an be used to automatically stop the conmonrs server after DELAY seconds of inactivity.
+	//
+	// 0 = disabled (run until manually stopped by client.Shutdown)
+	ShutdownDelay time.Duration
 }
 
 // Tracing is the structure for managing server-side OpenTelemetry tracing.
@@ -337,6 +342,10 @@ func (c *ConmonClient) toArgs(config *ConmonServerConfig) (entrypoint string, ar
 		if config.Tracing.Endpoint != "" {
 			args = append(args, "--tracing-endpoint", config.Tracing.Endpoint)
 		}
+	}
+
+	if config.ShutdownDelay > 0 {
+		args = append(args, "--shutdown-delay", fmt.Sprint(config.ShutdownDelay.Seconds()))
 	}
 
 	return entrypoint, args, nil


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This adds a new option to enable automatic shutdown: After a configurable period of inactivity the server automatically shuts itself down.

The following activity is tracked and prevents shutdown:
- A connected RPC client
- A running `ReapableChild` of the child reaper (= a running container)
- A running cleanup process

The new FD socket server also shuts itself down after 3 seconds of inactivity (= no connected clients).

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
The FD socket inactivity period is hardcoded as 3 seconds. This is enough time for the client to connect to the FD socket path, after the client invoked the `StartFdSocket` RPC method. This could also be configurable.

#### Does this PR introduce a user-facing change?

```release-note
Add an option to enable automatic shutdown after a configurable period of inactivity
```
