### PR TITLE
Change resize channel to receive only

### DIFF
--- a/pkg/client/attach.go
+++ b/pkg/client/attach.go
@@ -74,7 +74,7 @@ type AttachConfig struct {
 	Passthrough bool
 
 	// Channel of resize events.
-	Resize chan resize.TerminalSize
+	Resize <-chan resize.TerminalSize
 
 	// The standard streams for this attach session.
 	Streams AttachStreams


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
The `Resize` channel in the `AttachConfig` go struct was not restricted. This PR changes the channel to a receive only channel.

```diff
-	Resize chan resize.TerminalSize
+	Resize <-chan resize.TerminalSize
```

The channel is only used for receive operations.

**Note:** This is technically a breaking change as the following code would no longer work:

```go
config := new(client.AttachConfig)
config.Resize = make(chan resize.TerminalSize, 1)
config.Resize <- size
```

But this is an uncommon usage pattern. The following pattern is more expected (used by CRI-O) and is unaffected by this change:
```go
resize := make(chan resize.TerminalSize, 1)
resize <- size

config := new(client.AttachConfig)
config.Resize = resize
```

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```
