### PR TITLE
Fix stop after EOF error condition

### DIFF
--- a/pkg/client/attach.go
+++ b/pkg/client/attach.go
@@ -270,7 +270,7 @@ func (c *ConmonClient) redirectResponseToOutputStreams(
 				return nil
 			}
 		}
-		if er == io.EOF || (cfg.ContainerStdin && !cfg.StopAfterStdinEOF) {
+		if er == io.EOF && cfg.ContainerStdin && !cfg.StopAfterStdinEOF {
 			return nil
 		}
 		if errors.Is(er, syscall.ECONNRESET) {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
While implementing attach for podman the attach stream would never terminate (at least without setting `cfg.StopAfterStdinEOF`, but then it would not wait for all output).

This change fixes this issue in my case, but it might be the wrong fix. Maybe it should instead be just the following:
```go
if er == io.EOF {
    return nil
}
```

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```
