### PR TITLE
Fix early stdio close due to multiple ownership

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,7 +365,6 @@ dependencies = [
  "time",
  "tokio",
  "tokio-eventfd",
- "tokio-fd",
  "tokio-seqpacket",
  "tokio-util",
  "tracing",
@@ -2064,16 +2063,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8574d08892a39f0d7b9d19e1884bf334811dd46f96a4334926858c51a3944f0"
 dependencies = [
  "futures-lite",
- "libc",
- "tokio",
-]
-
-[[package]]
-name = "tokio-fd"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cedf0b897610a4baff98bf6116c060c5cfe7574d4339c50e9d23fe09377641d"
-dependencies = [
  "libc",
  "tokio",
 ]

--- a/conmon-rs/server/Cargo.toml
+++ b/conmon-rs/server/Cargo.toml
@@ -37,7 +37,6 @@ strum = { version = "0.25.0", features = ["derive"] }
 tempfile = "3.8.0"
 tokio = { version = "1.32.0", features = ["fs", "io-std", "io-util", "macros", "net", "process", "rt", "rt-multi-thread", "signal", "time"] }
 tokio-eventfd = "0.2.1"
-tokio-fd = "0.3.0"
 tokio-seqpacket = "0.7.0"
 tokio-util = { version = "0.7.8", features = ["compat"] }
 tracing = "0.1.37"

--- a/conmon-rs/server/src/streams.rs
+++ b/conmon-rs/server/src/streams.rs
@@ -7,7 +7,6 @@ use crate::{
 };
 use anyhow::Result;
 use getset::Getters;
-use std::os::unix::io::AsRawFd;
 use tokio::{
     process::{ChildStderr, ChildStdin, ChildStdout},
     sync::mpsc::{self, UnboundedReceiver, UnboundedSender},
@@ -68,9 +67,7 @@ impl Streams {
         if let Some(stdin) = stdin {
             task::spawn(
                 async move {
-                    if let Err(e) =
-                        ContainerIO::read_loop_stdin(stdin.as_raw_fd(), attach, token).await
-                    {
+                    if let Err(e) = ContainerIO::read_loop_stdin(stdin, attach, token).await {
                         error!("Stdin read loop failure: {:#}", e);
                     }
                 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
The `ContainerIO::read_loop_stdin` function was taking the fd to stdin as a `RawFd` and took ownership of the file descriptor. This worked for piped IO (`streams.rs`) but not for tty based IO (`terminal.rs`).

With tty based IO the same file descriptor was used as an `AsyncFd` and passed to `read_loop_stdin` this resulted in two owners of the same file descriptor. The first owner (stdin in most cases) would close the fd on drop. The second owner would stall as it won't be notified that the fd closed and once the second owner would drop it would try to close the same fd again. Which could have been reused in the meantime.

This change refactors `ContainerIO::read_loop_stdin` to take an implementation of `AsyncWrite` and introduces a new `TerminalFd` which wraps the pty file descriptor and implements  `AsyncRead` and `AsyncWrite` for references to itself. This allows us to use reference counting to close the file descriptor only after both the `read_loop_stdin` and `read_loop` terminate.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```
