### PR TITLE
Fix get script for tags

### DIFF
--- a/.github/create-marker
+++ b/.github/create-marker
@@ -9,6 +9,6 @@ VERSION=$(git rev-parse HEAD)
 if [[ $MARKER == HEAD ]]; then
     # use the major.minor as marker
     VERSION=$(git describe --tags --exact-match)
-    MARKER=$(echo "$VERSION" | cut -c 2-5)
+    MARKER=$(echo "$VERSION" | cut -c 2-4)
 fi
 echo "$VERSION" >"latest-$MARKER.txt"

--- a/scripts/get
+++ b/scripts/get
@@ -60,14 +60,30 @@ curl_retry() {
 }
 
 download_binary() {
+    GIT_REF=refs/heads/main
+
     if [[ $TAG != "" ]]; then
         echo "Getting commit from tag"
-        COMMIT=$(curl_retry "https://api.github.com/repos/containers/conmon-rs/git/refs/tags/$TAG" | jq -r .object.sha)
-    elif [[ $COMMIT == "" ]]; then
-        echo "Getting latest commit on main"
-        COMMIT=$(curl_retry $BASE_URL/latest-main.txt)
+        TAG_JSON=$(curl_retry "https://api.github.com/repos/containers/conmon-rs/git/refs/tags/$TAG")
+        COMMIT=$(echo "$TAG_JSON" | jq -r .object.sha)
+        GIT_REF=$(echo "$TAG_JSON" | jq -r .ref)
+    else
+        if [[ $COMMIT == "" ]]; then
+            echo "Getting latest commit on main"
+            COMMIT=$(curl_retry $BASE_URL/latest-main.txt)
+        fi
+
+        # Latest commit can be a tag
+        POSSIBLE_TAG_JSON=$(curl_retry "https://api.github.com/repos/containers/conmon-rs/git/refs/tags" | jq '.[] | select(.object.sha == "'"$COMMIT"'")')
+
+        if [[ $POSSIBLE_TAG_JSON != "" ]]; then
+            GIT_REF=$(echo "$POSSIBLE_TAG_JSON" | jq -r .ref)
+            echo "Commit $COMMIT is tag ref $TAG"
+        fi
     fi
+
     echo "Found commit: $COMMIT"
+    echo "Using git ref: $GIT_REF"
 
     mkdir -p "$(dirname "$OUTPUT")"
 
@@ -83,13 +99,12 @@ download_binary() {
         done
 
         SLUG=containers/conmon-rs
-        GIT_REF=refs/heads/main
         cosign verify-blob conmonrs \
             --certificate-identity "https://github.com/$SLUG/.github/workflows/ci.yml@$GIT_REF" \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
             --certificate-github-workflow-name ci \
             --certificate-github-workflow-repository "$SLUG" \
-            --certificate-github-workflow-ref $GIT_REF \
+            --certificate-github-workflow-ref "$GIT_REF" \
             --signature conmonrs.sig \
             --certificate conmonrs.cert
 


### PR DESCRIPTION


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
We have to specify the right git ref for cosign to let the script work correctly on tags.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed correct git ref usage for get script when being used on tags.
```
