### PR TITLE
Set resolver to v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "conmon-common"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "capnp",
  "capnpc",
@@ -331,7 +331,7 @@ dependencies = [
 
 [[package]]
 name = "conmonrs"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "capnp",
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "conmonrs-cli"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "capnp",
  "capnp-rpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
 	"conmon-rs/common",
 	"conmon-rs/client",


### PR DESCRIPTION

#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
Cargo complains that the resolver is not set. We now default to v2 and update the lockfile.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
