### PR TITLE
Add nix build for multi-arch static binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ env:
   CARGO_TERM_COLOR: always
   GO_VERSION: '1.20'
   ACTION_MSRV_TOOLCHAIN: 1.69.0
+  NIX_VERSION: '2.17.0'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -120,6 +121,54 @@ jobs:
         with:
           path: .
           glob: latest-*.txt
+          destination: cri-o/conmon-rs
+
+  build-static:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64, ppc64le]
+    name: build-static-${{ matrix.arch }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v23
+        with:
+          install_url: https://releases.nixos.org/nix/nix-${{ env.NIX_VERSION }}/install
+      - uses: cachix/cachix-action@v12
+        with:
+          name: conmon-rs
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          pushFilter: "(conmon-rs|cargo-vendor)"
+      - run: nix-build nix/default-${{ matrix.arch }}.nix
+      - run: file result/bin/conmonrs | grep static | grep stripped
+      - uses: actions/upload-artifact@v3
+        with:
+          name: build-static-${{ matrix.arch }}
+          path: |
+            result/bin/conmonrs
+      - run: |
+          mkdir ${{ github.sha }}
+          cp result/bin/conmonrs ${{ github.sha }}/conmonrs.${{ matrix.arch }}
+      - uses: sigstore/cosign-installer@v3
+      - name: Sign binary
+        if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags')
+        run: |
+          cd ${{ github.sha }}
+          cosign sign-blob -y conmonrs.${{ matrix.arch }} \
+            --output-signature conmonrs.${{ matrix.arch }}.sig \
+            --output-certificate conmonrs.${{ matrix.arch }}.cert
+      - uses: actions/upload-artifact@v3
+        with:
+          name: conmonrs
+          path: ${{ github.sha }}/*
+      - uses: google-github-actions/auth@v1
+        if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags')
+        with:
+          credentials_json: ${{ secrets.GCS_CRIO_SA }}
+      - uses: google-github-actions/upload-cloud-storage@v1
+        if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags')
+        with:
+          path: ${{ github.sha }}
           destination: cri-o/conmon-rs
 
   doc:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.orig
 *.test
 /target
+/result
 /vendor
 .build
 latest-*.txt

--- a/Makefile
+++ b/Makefile
@@ -108,3 +108,7 @@ install:
 .PHONY: rpm
 rpm:
 	rpkg local
+
+nixpkgs:
+	@nix run -f channel:nixpkgs-unstable nix-prefetch-git -- \
+		--no-deepClone https://github.com/nixos/nixpkgs > nix/nixpkgs.json

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -49,3 +49,9 @@ dependencies:
     refPaths:
       - path: contrib/tracing/start
         match: OTLP_IMG
+
+  - name: nix
+    version: 2.17.0
+    refPaths:
+      - path: .github/workflows/ci.yml
+        match: NIX_VERSION

--- a/nix/default-amd64.nix
+++ b/nix/default-amd64.nix
@@ -1,0 +1,1 @@
+default.nix

--- a/nix/default-arm64.nix
+++ b/nix/default-arm64.nix
@@ -1,0 +1,7 @@
+(import ./nixpkgs.nix {
+  crossSystem = {
+    config = "aarch64-unknown-linux-gnu";
+  };
+  overlays = [ (import ./overlay.nix) ];
+}).callPackage ./derivation.nix
+{ }

--- a/nix/default-ppc64le.nix
+++ b/nix/default-ppc64le.nix
@@ -1,0 +1,7 @@
+(import ./nixpkgs.nix {
+  crossSystem = {
+    config = "powerpc64le-unknown-linux-gnu";
+  };
+  overlays = [ (import ./overlay.nix) ];
+}).callPackage ./derivation.nix
+{ }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,4 @@
+(import ./nixpkgs.nix {
+  overlays = [ (import ./overlay.nix) ];
+}).callPackage ./derivation.nix
+{ }

--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -1,0 +1,23 @@
+{ pkgs }:
+with pkgs; rustPlatform.buildRustPackage {
+  name = "conmon-rs";
+  src = ./..;
+  doCheck = false;
+  nativeBuildInputs = with buildPackages; [
+    capnproto
+    protobuf
+  ];
+  buildInputs = [
+    glibc
+    glibc.static
+  ];
+  RUSTFLAGS = [
+    "-Ctarget-feature=+crt-static"
+  ];
+  stripAllList = [ "bin" ];
+  cargoLock = {
+    lockFile = lib.cleanSource ./.. + "/Cargo.lock";
+    allowBuiltinFetchGit = true;
+  };
+}
+

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,0 +1,12 @@
+{
+  "url": "https://github.com/nixos/nixpkgs",
+  "rev": "c44317643ebf160b50a86a23d203d99aaee8c133",
+  "date": "2023-09-08T07:22:05+00:00",
+  "path": "/nix/store/gscd59h9fppxwblgz19q24wg0jj8x4gg-nixpkgs",
+  "sha256": "1kr94ygwqirgmfpzyz3qz3wjfp28rqbmz2n565mssrlk0j3khwqx",
+  "hash": "sha256-HXM4hwSTZq1rMcWKXxfOSFwn+fh4fP+vqy9HzJ8nKc8=",
+  "fetchLFS": false,
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,0 +1,8 @@
+let
+  json = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
+  nixpkgs = import (builtins.fetchTarball {
+    name = "nixos-unstable";
+    url = "${json.url}/tarball/${json.rev}";
+    inherit (json) sha256;
+  });
+in nixpkgs

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,5 @@
+let
+  static = import ./static.nix;
+in
+self: super:
+{ }

--- a/nix/static.nix
+++ b/nix/static.nix
@@ -1,0 +1,10 @@
+pkg: pkg.overrideAttrs (x: {
+  doCheck = false;
+  configureFlags = (x.configureFlags or [ ]) ++ [
+    "--without-shared"
+    "--disable-shared"
+  ];
+  dontDisableStatic = true;
+  enableSharedExecutables = false;
+  enableStatic = true;
+})


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
Allow multi-arch statically linked binaries for amd64, arm64 and ppc64le.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added multi-arch static binaries for amd64, arm64 and ppc64le.
```
