### PR TITLE
Fix constant int overflow for `GOARCH=386`

### DIFF
--- a/pkg/client/remote_fds.go
+++ b/pkg/client/remote_fds.go
@@ -98,7 +98,7 @@ func (r *RemoteFDs) Send(fds ...int) ([]RemoteFD, error) {
 	}
 
 	numFDs := int(resIDAndNumFDs & (1<<numFDsBits - 1))
-	if numFDs == 1<<numFDsBits-1 {
+	if int64(numFDs) == 1<<numFDsBits-1 {
 		return nil, serverError(buf)
 	}
 


### PR DESCRIPTION


#### What type of PR is this?


/kind bug

#### What this PR does / why we need it:
Fixing the build for:

```
> GOARCH=386 go build ./...
pkg/client/remote_fds.go:101:15: invalid operation: numFDs == int64(1) << int64(numFDsBits) (mismatched types int and int64)
```
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed constant int overflow for `GOARCH=386`.
```
