### PR TITLE
Create marker only if CI passed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,10 +115,19 @@ jobs:
         with:
           path: ${{ github.sha }}
           destination: cri-o/conmon-rs
+
+  create-marker:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags')
+    needs:
+      - release-static
+      - build-static
+    steps:
       - run: .github/create-marker
-        if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags')
+      - uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GCS_CRIO_SA }}
       - uses: google-github-actions/upload-cloud-storage@v1
-        if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags')
         with:
           path: .
           glob: latest-*.txt


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
We now make a dedicated `create-marker` step which runs only if all static builds passed. Otherwise we'll risk that the get-script points to a non completed commit resulting in a 404.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
