### PR TITLE
Bump max rss to 7500

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ integration-static: .install.ginkgo # It needs to be release so we correctly tes
 		$(MAKE) release-static; \
 	fi && \
 	export RUNTIME_BINARY="$(RUNTIME_PATH)" && \
-	export MAX_RSS_KB=5000 && \
+	export MAX_RSS_KB=7500 && \
 	sudo -E "$(GOTOOLS_BINDIR)/ginkgo" $(TEST_FLAGS) $(GINKGO_FLAGS)
 
 .install.ginkgo:

--- a/pkg/client/suite_test.go
+++ b/pkg/client/suite_test.go
@@ -38,7 +38,7 @@ var (
 	busyboxDest = filepath.Join(busyboxDestDir, "busybox")
 	runtimePath = os.Getenv("RUNTIME_BINARY")
 	conmonPath  = os.Getenv(conmonBinaryKey)
-	maxRSSKB    = 5000
+	maxRSSKB    = 7500
 )
 
 // TestConmonClient runs the created specs.


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
I assume that the recent runner image release causes the binary to consume more RSS:
https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20230911.1

Nothing obvious has changed between the successfull and failing runs other than the runner image, so it could be also related to the kernel bump from `5.15.0-1041-azure` to `6.2.0-1011-azure`.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
