### PR TITLE
Switch to `crio status`

### DIFF
--- a/.github/setup
+++ b/.github/setup
@@ -55,8 +55,8 @@ EOT
     sudo systemctl enable --now crio.service
 
     # Validate if the correct config is being loaded
-    sudo crio-status config | grep -q 'default_runtime = "runc"'
-    sudo crio-status config | grep -q 'runtime_type = "pod"'
+    sudo crio status config | grep -q 'default_runtime = "runc"'
+    sudo crio status config | grep -q 'runtime_type = "pod"'
 }
 
 install_critest() {


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
The `crio-status` binary got removed from the static binary bundles so we have to use `crio status` instead.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
