### PR TITLE
Packit: switch to EPEL instead of centos-stream+epel-next

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -26,10 +26,10 @@ jobs:
     targets:
       - fedora-all-x86_64
       - fedora-all-aarch64
-      - centos-stream+epel-next-8-x86_64
-      - centos-stream+epel-next-8-aarch64
-      - centos-stream+epel-next-9-x86_64
-      - centos-stream+epel-next-9-aarch64
+      - epel-8-x86_64
+      - epel-8-aarch64
+      - epel-9-x86_64
+      - epel-9-aarch64
     additional_repos:
       - "copr://rhcontainerbot/podman-next"
 


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
EPEL is the recommended target for further testing with rpm builds.

cc @lsm5 
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Similar to https://github.com/containers/podman/pull/22432
#### Special notes for your reviewer:
/hold
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
