### PR TITLE
Build s390x binaries using musl libc

### DIFF
--- a/conmon-rs/common/src/lib.rs
+++ b/conmon-rs/common/src/lib.rs
@@ -2,3 +2,93 @@
 pub mod conmon_capnp {
     include!(concat!(env!("OUT_DIR"), "/proto/conmon_capnp.rs"));
 }
+
+/// Workaround for rustc bug: https://github.com/rust-lang/rust/issues/47493
+///
+/// It shouldn't even be possible to reach this function, thanks to panic=abort,
+/// but libcore is compiled with unwinding enabled and that ends up making unreachable
+/// references to this.
+#[cfg(all(target_os = "linux", target_arch = "s390x", target_env = "musl"))]
+mod unwind {
+    #[no_mangle]
+    unsafe extern "C" fn _Unwind_Backtrace() {
+        unimplemented!("_Unwind_Backtrace")
+    }
+    #[no_mangle]
+    unsafe extern "C" fn _Unwind_DeleteException() {
+        unimplemented!("_Unwind_DeleteException")
+    }
+    #[no_mangle]
+    unsafe extern "C" fn _Unwind_GetDataRelBase() {
+        unimplemented!("_Unwind_GetDataRelBase")
+    }
+    #[no_mangle]
+    unsafe extern "C" fn _Unwind_GetIP() {
+        unimplemented!("_Unwind_GetIP")
+    }
+    #[no_mangle]
+    unsafe extern "C" fn _Unwind_GetIPInfo() {
+        unimplemented!("_Unwind_GetIPInfo")
+    }
+    #[no_mangle]
+    unsafe extern "C" fn _Unwind_GetLanguageSpecificData() {
+        unimplemented!("_Unwind_GetLanguageSpecificData")
+    }
+    #[no_mangle]
+    unsafe extern "C" fn _Unwind_GetRegionStart() {
+        unimplemented!("_Unwind_GetRegionStart")
+    }
+    #[no_mangle]
+    unsafe extern "C" fn _Unwind_GetTextRelBase() {
+        unimplemented!("_Unwind_GetTextRelBase")
+    }
+    #[no_mangle]
+    unsafe extern "C" fn _Unwind_RaiseException() {
+        unimplemented!("_Unwind_RaiseException")
+    }
+    #[no_mangle]
+    unsafe extern "C" fn _Unwind_Resume() {
+        unimplemented!("_Unwind_Resume")
+    }
+    #[no_mangle]
+    unsafe extern "C" fn _Unwind_SetGR() {
+        unimplemented!("_Unwind_SetGR")
+    }
+    #[no_mangle]
+    unsafe extern "C" fn _Unwind_SetIP() {
+        unimplemented!("_Unwind_SetIP")
+    }
+    #[no_mangle]
+    unsafe extern "C" fn _Unwind_FindEnclosingFunction() {
+        unimplemented!("_Unwind_FindEnclosingFunction")
+    }
+    #[no_mangle]
+    unsafe extern "C" fn _Unwind_GetCFA() {
+        unimplemented!("_Unwind_GetCFA")
+    }
+    #[cfg(target_arch = "arm")]
+    #[no_mangle]
+    unsafe extern "C" fn _Unwind_VRS_Get() {
+        unimplemented!("_Unwind_VRS_Get")
+    }
+    #[cfg(target_arch = "arm")]
+    #[no_mangle]
+    unsafe extern "C" fn _Unwind_VRS_Set() {
+        unimplemented!("_Unwind_VRS_Set")
+    }
+    #[cfg(target_arch = "arm")]
+    #[no_mangle]
+    unsafe extern "C" fn __aeabi_unwind_cpp_pr0() {
+        unimplemented!("__aeabi_unwind_cpp_pr0")
+    }
+    #[cfg(target_arch = "arm")]
+    #[no_mangle]
+    unsafe extern "C" fn __aeabi_unwind_cpp_pr1() {
+        unimplemented!("__aeabi_unwind_cpp_pr1")
+    }
+    #[cfg(target_arch = "arm")]
+    #[no_mangle]
+    unsafe extern "C" fn __gnu_unwind_frame() {
+        unimplemented!("__gnu_unwind_frame")
+    }
+}

--- a/nix/default-s390x.nix
+++ b/nix/default-s390x.nix
@@ -1,6 +1,9 @@
 (import ./nixpkgs.nix {
   crossSystem = {
-    config = "s390x-unknown-linux-gnu";
+    # TODO: Switch back to glibc when
+    # https://github.com/NixOS/nixpkgs/issues/306473
+    # is resolved.
+    config = "s390x-unknown-linux-musl";
   };
   overlays = [ (import ./overlay.nix) ];
 }).callPackage ./derivation.nix

--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -7,13 +7,25 @@ with pkgs; rustPlatform.buildRustPackage {
     capnproto
     protobuf
   ];
-  buildInputs = [
-    glibc
-    glibc.static
-  ];
+  buildInputs =
+    if stdenv.hostPlatform.isMusl then [
+      libunwind
+    ] else [
+      glibc
+      glibc.static
+    ];
   RUSTFLAGS = [
     "-Ctarget-feature=+crt-static"
+  ] ++ lib.optionals stdenv.hostPlatform.isMusl [
+    "-Cpanic=abort"
+    "-Clink-args=-nostartfiles"
+    "-Clink-args=-L${libunwind}/lib"
   ];
+  # Patch nix v0.27.1 for musl
+  preBuild = lib.optionalString stdenv.hostPlatform.isMusl ''
+    sed -i 's;target_arch = "s390x";target_arch = "s390x" , not(target_env = "musl");g' \
+      /build/cargo-vendor-dir/nix-0.27.1/src/sys/statfs.rs
+  '';
   stripAllList = [ "bin" ];
   cargoLock = {
     lockFile = lib.cleanSource ./.. + "/Cargo.lock";

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -2,4 +2,6 @@ let
   static = import ./static.nix;
 in
 self: super:
-{ }
+{
+  libunwind = (static super.libunwind);
+}


### PR DESCRIPTION


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
Building using musl until NixOS/nixpkgs#306473 is resolved.


#### Which issue(s) this PR fixes:

Refers to cri-o/cri-o#7911

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed s390x build using musl libc.
```
