### PR TITLE
Use `.gitignore` in nix build excludes

### DIFF
--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -1,7 +1,8 @@
 { pkgs }:
 with pkgs; rustPlatform.buildRustPackage {
   name = "conmon-rs";
-  src = ./..;
+  # Use Pure to avoid exuding the .git directory
+  src = nix-gitignore.gitignoreSourcePure [ ../.gitignore ] ./..;
   doCheck = false;
   nativeBuildInputs = with buildPackages; [
     capnproto


### PR DESCRIPTION
#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
This avoids building with wrong pre-built data locally as well as in CI.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
