### PR TITLE
Update go-capnp package to fix build issue on Go 1.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,7 +321,7 @@ jobs:
       - name: create symlink
         run: sudo ln -f -s $(go env GOROOT)/bin/* /usr/bin/
       - name: Integration tests
-        run: RUNTIME_PATH="/usr/sbin/runc" make integration-static
+        run: sudo -E RUNTIME_PATH="/usr/sbin/runc" make integration-static
       - name: Chown cache
         run: |
           sudo chown -R $(id -u):$(id -g) ~/go/pkg/mod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Select Toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env['ACTION_MSRV_TOOLCHAIN']  }}
+          toolchain: ${{ env['ACTION_MSRV_TOOLCHAIN'] }}
           default: true
           override: true
           components: rustfmt
@@ -86,7 +86,7 @@ jobs:
           # Ubuntu 22.04 glibc static is not compatible with rustc 1.58.1 (see
           # ACTION_MSRV_TOOLCHAIN). Means we now just use the latest one, since
           # the static builds are made for the community.
-          toolchain: stable
+          toolchain: ${{ env['ACTION_MSRV_TOOLCHAIN'] }}
           default: true
           override: true
           components: rustfmt
@@ -207,7 +207,7 @@ jobs:
       - name: Select Toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env['ACTION_MSRV_TOOLCHAIN']  }}
+          toolchain: ${{ env['ACTION_MSRV_TOOLCHAIN'] }}
           default: true
           override: true
           components: rustfmt
@@ -231,13 +231,13 @@ jobs:
       - name: Select Toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env['ACTION_MSRV_NIGHTLY_TOOLCHAIN']  }}
+          toolchain: ${{ env['ACTION_MSRV_NIGHTLY_TOOLCHAIN'] }}
           default: true
           override: true
           components: clippy, rustfmt
       - name: Clippy Lint
         run: |
-          cargo +${{ env['ACTION_MSRV_NIGHTLY_TOOLCHAIN']  }} clippy \
+          cargo +${{ env['ACTION_MSRV_NIGHTLY_TOOLCHAIN'] }} clippy \
             --all-targets --all-features -- -D warnings
 
   lint-rustfmt:
@@ -248,7 +248,7 @@ jobs:
       - name: Select Toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env['ACTION_MSRV_TOOLCHAIN']  }}
+          toolchain: ${{ env['ACTION_MSRV_TOOLCHAIN'] }}
           default: true
           override: true
           components: rustfmt
@@ -264,7 +264,7 @@ jobs:
       - name: Select Toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env['ACTION_MSRV_NIGHTLY_TOOLCHAIN']  }}
+          toolchain: ${{ env['ACTION_MSRV_NIGHTLY_TOOLCHAIN'] }}
           override: true
       - name: Install rustfmt
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Select Toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env['ACTION_MSRV_TOOLCHAIN']  }}
+          toolchain: ${{ env['ACTION_MSRV_TOOLCHAIN'] }}
           default: true
           override: true
           components: rustfmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1961,8 +1961,7 @@ dependencies = [
 [[package]]
 name = "time"
 version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
+source = "git+https://github.com/saschagrunert/time?rev=22f9ac760e36ca965a7205056f719d5db8d153c1#22f9ac760e36ca965a7205056f719d5db8d153c1"
 dependencies = [
  "itoa",
  "libc",
@@ -1975,14 +1974,12 @@ dependencies = [
 [[package]]
 name = "time-core"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+source = "git+https://github.com/saschagrunert/time?rev=22f9ac760e36ca965a7205056f719d5db8d153c1#22f9ac760e36ca965a7205056f719d5db8d153c1"
 
 [[package]]
 name = "time-macros"
 version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
+source = "git+https://github.com/saschagrunert/time?rev=22f9ac760e36ca965a7205056f719d5db8d153c1#22f9ac760e36ca965a7205056f719d5db8d153c1"
 dependencies = [
  "time-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,10 @@ lto = true
 opt-level = "z"
 incremental = true
 codegen-units = 1
+
+# Use this time-rs fork to fix the build issues with newer Rust. It's identical
+# to v0.3.23 version of the crate, except:
+#   https://github.com/saschagrunert/time/commit/22f9ac760e36ca965a7205056f719d5db8d153c1
+# TODO: Remove when we can use newer Rust versions than v1.66.1
+[patch.crates-io]
+time = { git = 'https://github.com/saschagrunert/time', rev = '22f9ac760e36ca965a7205056f719d5db8d153c1' }

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ integration: .install.ginkgo release # It needs to be release so we correctly te
 	export CONMON_BINARY="$(MAKEFILE_PATH)target/release/$(BINARY)" && \
 	export RUNTIME_BINARY="$(RUNTIME_PATH)" && \
 	export MAX_RSS_KB=10240 && \
-	sudo -E "$(GOTOOLS_BINDIR)/ginkgo" $(TEST_FLAGS) $(GINKGO_FLAGS)
+	"$(GOTOOLS_BINDIR)/ginkgo" $(TEST_FLAGS) $(GINKGO_FLAGS)
 
 integration-static: .install.ginkgo # It needs to be release so we correctly test the RSS usage
 	export CONMON_BINARY="$(MAKEFILE_PATH)target/x86_64-unknown-linux-gnu/release/$(BINARY)" && \
@@ -56,7 +56,7 @@ integration-static: .install.ginkgo # It needs to be release so we correctly tes
 	fi && \
 	export RUNTIME_BINARY="$(RUNTIME_PATH)" && \
 	export MAX_RSS_KB=9500 && \
-	sudo -E "$(GOTOOLS_BINDIR)/ginkgo" $(TEST_FLAGS) $(GINKGO_FLAGS)
+	"$(GOTOOLS_BINDIR)/ginkgo" $(TEST_FLAGS) $(GINKGO_FLAGS)
 
 .install.ginkgo:
 	GOBIN=$(abspath $(GOTOOLS_BINDIR)) \

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/containers/conmon-rs
 go 1.22
 
 require (
-	capnproto.org/go/capnp/v3 v3.0.0-alpha.25
+	capnproto.org/go/capnp/v3 v3.0.1-alpha.2
 	github.com/blang/semver/v4 v4.0.0
 	github.com/containers/common v0.59.2
 	github.com/containers/storage v1.54.0
@@ -18,6 +18,7 @@ require (
 )
 
 require (
+	github.com/colega/zeropool v0.0.0-20230505084239-6fb4a4f75381 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.5 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
@@ -40,5 +41,4 @@ require (
 	golang.org/x/text v0.15.0 // indirect
 	golang.org/x/tools v0.21.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	zenhack.net/go/util v0.0.0-20230218002511-744d2d6d1739 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,9 @@
-capnproto.org/go/capnp/v3 v3.0.0-alpha.25 h1:VfSMVPjhSJMe+SMtbaBgFS5a2BLo4W2HHhd5M2EivUI=
-capnproto.org/go/capnp/v3 v3.0.0-alpha.25/go.mod h1:SazsSKIo0mjdwYyEMD8l65Tvg5pvm2kO1emuWa1+YB4=
+capnproto.org/go/capnp/v3 v3.0.1-alpha.2 h1:W/cf+XEArUSwcBBE/9wS2NpWDkM5NLQOjmzEiHZpYi0=
+capnproto.org/go/capnp/v3 v3.0.1-alpha.2/go.mod h1:2vT5D2dtG8sJGEoEKU17e+j7shdaYp1Myl8X03B3hmc=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
+github.com/colega/zeropool v0.0.0-20230505084239-6fb4a4f75381 h1:d5EKgQfRQvO97jnISfR89AiCCCJMwMFoSxUiU0OGCRU=
+github.com/colega/zeropool v0.0.0-20230505084239-6fb4a4f75381/go.mod h1:OU76gHeRo8xrzGJU3F3I1CqX1ekM8dfJw0+wPeMwnp0=
 github.com/containers/common v0.59.2 h1:FcURZzlMYMVZXqjMEop6C0A3yWilrfmWUPUw09APHvI=
 github.com/containers/common v0.59.2/go.mod h1:/PHpbapKSHQU29Jmjn3Ld3jekoHvX0zx7qQxxyPqSTM=
 github.com/containers/storage v1.54.0 h1:xwYAlf6n9OnIlURQLLg3FYHbO74fQ/2W2N6EtQEUM4I=
@@ -52,8 +54,8 @@ github.com/opencontainers/runtime-tools v0.9.1-0.20230914150019-408c51e934dc h1:
 github.com/opencontainers/runtime-tools v0.9.1-0.20230914150019-408c51e934dc/go.mod h1:8tx1helyqhUC65McMm3x7HmOex8lO2/v9zPuxmKHurs=
 github.com/opencontainers/selinux v1.11.0 h1:+5Zbo97w3Lbmb3PeqQtpmTkMwsW5nRI3YaLpt7tQ7oU=
 github.com/opencontainers/selinux v1.11.0/go.mod h1:E5dMC3VPuVvVHDYmi78qvhJp8+M586T4DlDRYpFkyec=
-github.com/philhofer/fwd v1.1.1 h1:GdGcTjf5RNAxwS4QLsiMzJYj5KEvPJD3Abr261yRQXQ=
-github.com/philhofer/fwd v1.1.1/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
+github.com/philhofer/fwd v1.1.2 h1:bnDivRJ1EWPjUIRXV5KfORO897HTbpFAQddBdE8t7Gw=
+github.com/philhofer/fwd v1.1.2/go.mod h1:qkPdfjR2SIEbspLqpe1tO4n5yICnr2DY7mqEx2tUTP0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -67,8 +69,10 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
-github.com/tinylib/msgp v1.1.5 h1:2gXmtWueD2HefZHQe1QOy9HVzmFrLOVvsXwXBQ0ayy0=
-github.com/tinylib/msgp v1.1.5/go.mod h1:eQsjooMTnV42mHu917E26IogZ2930nFyBQdofk10Udg=
+github.com/tinylib/msgp v1.1.9 h1:SHf3yoO2sGA0veCJeCBYLHuttAVFHGm2RHgNodW7wQU=
+github.com/tinylib/msgp v1.1.9/go.mod h1:BCXGB54lDD8qUEPmiG0cQQUANC4IUQyB2ItS2UDlO/k=
+github.com/tj/assert v0.0.3 h1:Df/BlaZ20mq6kuai7f5z2TvPFiwC3xaWJSDQNiIS3Rk=
+github.com/tj/assert v0.0.3/go.mod h1:Ne6X72Q+TB1AteidzQncjw9PabbMp4PBMZ1k+vd1Pvk=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
@@ -100,5 +104,3 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-zenhack.net/go/util v0.0.0-20230218002511-744d2d6d1739 h1:/QnbZBURrZUFvnxB4wDyRrPsWzh2KWbJ6AjUjohCHJ8=
-zenhack.net/go/util v0.0.0-20230218002511-744d2d6d1739/go.mod h1:0lafdGg7tDb7RcXASgmJmRbLFLkAxu328+KGIs7icDE=

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -887,8 +887,10 @@ func (c *ConmonClient) ExecSyncContainer(ctx context.Context, cfg *ExecSyncConfi
 
 	execContainerResult := &ExecContainerResult{
 		ExitCode: resp.ExitCode(),
-		Stdout:   stdout,
-		Stderr:   stderr,
+		// Copy content of both slices as the `capnp.ReleaseFunc` will
+		// zero them when the deferred call to `free()` takes place.
+		Stdout:   append(stdout[:0:0], stdout...),
+		Stderr:   append(stderr[:0:0], stderr...),
 		TimedOut: resp.TimedOut(),
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind dependency-change

#### What this PR does / why we need it:

When building the [go-capnp](https://github.com/capnproto/go-capnp) using Go 1.23 or Go tip, the following build error will be reported (an example build failure from the CRI-O project):

```console
# capnproto.org/go/capnp/v3
vendor/capnproto.org/go/capnp/v3/list.go:1087:10: invalid composite literal type T
```

Thus, upgrade the go-capnp version to [v3.0.1-alpha.2](https://github.com/capnproto/go-capnp/releases/tag/v3.0.1-alpha.2), which would fix the build issue on a newer version of Go.

Related:

- https://github.com/capnproto/go-capnp/pull/576
- https://github.com/cri-o/cri-o/issues/8373

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```
