### PR TITLE
WIP: Manually select runtime endpoint for `critest` CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,11 +341,10 @@ jobs:
         with:
           name: conmonrs
           path: target/x86_64-unknown-linux-musl/release
-      - run: sudo cp target/x86_64-unknown-linux-musl/release/conmonrs /usr/local/bin
-      - run: sudo chmod +x /usr/local/bin/conmonrs
+      - run: sudo cp target/x86_64-unknown-linux-musl/release/conmonrs /usr/libexec/crio/conmonrs
       - run: .github/setup
       - name: Run critest
-        run: sudo critest
+        run: sudo critest --runtime-endpoint unix:///var/run/crio/crio.sock
 
   typos:
     runs-on: ubuntu-latest


### PR DESCRIPTION


#### What type of PR is this?


/kind failing-test

#### What this PR does / why we need it:
It looks like critest will auto-pick the containerd endpoint, which is now set manually to the CRI-O instance.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
