### PR TITLE
Use new CRI-O libexec path for `conmonrs` binary

### DIFF
--- a/.github/setup
+++ b/.github/setup
@@ -50,6 +50,7 @@ seccomp_use_default_when_empty = false
 
 [crio.runtime.runtimes.runc]
 runtime_type = "pod"
+runtime_path = "/usr/libexec/crio/conmonrs"
 EOT
 
     sudo systemctl enable --now crio.service

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,9 +341,8 @@ jobs:
         with:
           name: conmonrs
           path: target/x86_64-unknown-linux-musl/release
-      - run: sudo cp target/x86_64-unknown-linux-musl/release/conmonrs /usr/local/bin
-      - run: sudo chmod +x /usr/local/bin/conmonrs
       - run: .github/setup
+      - run: sudo cp target/x86_64-unknown-linux-musl/release/conmonrs /usr/libexec/crio/conmonrs
       - name: Run critest
         run: sudo critest
 


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
Should work after https://github.com/kubernetes-sigs/cri-tools/pull/1507 got merged.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
