### PR TITLE
Remove `time` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,7 +388,6 @@ dependencies = [
  "signal-hook",
  "strum",
  "tempfile",
- "time",
  "tokio",
  "tokio-eventfd",
  "tokio-seqpacket",

--- a/conmon-rs/server/Cargo.toml
+++ b/conmon-rs/server/Cargo.toml
@@ -53,4 +53,3 @@ dashmap = "6.0.1"
 
 [dev-dependencies]
 mockall = "0.13.0"
-time = { version = "0.3.23", features = ["parsing"] }


### PR DESCRIPTION

#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
The pinned dependency does break builds with the latest rust versions. It looks like we do not need it at all, though.
#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Removed `time` build dependency.
```
