### PR TITLE
WIP: Use `time` fork to fix build on newer Rust versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,7 +388,7 @@ dependencies = [
  "signal-hook",
  "strum",
  "tempfile",
- "time",
+ "time 0.3.23 (git+https://github.com/saschagrunert/time?branch=v0.3.23-fix)",
  "tokio",
  "tokio-eventfd",
  "tokio-seqpacket",
@@ -1781,7 +1781,7 @@ dependencies = [
  "const_format",
  "git2",
  "is_debug",
- "time",
+ "time 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "tzdb",
 ]
 
@@ -1968,8 +1968,18 @@ dependencies = [
  "libc",
  "num_threads",
  "serde",
- "time-core",
- "time-macros",
+ "time-core 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time-macros 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "time"
+version = "0.3.23"
+source = "git+https://github.com/saschagrunert/time?branch=v0.3.23-fix#22f9ac760e36ca965a7205056f719d5db8d153c1"
+dependencies = [
+ "serde",
+ "time-core 0.1.1 (git+https://github.com/saschagrunert/time?branch=v0.3.23-fix)",
+ "time-macros 0.2.10 (git+https://github.com/saschagrunert/time?branch=v0.3.23-fix)",
 ]
 
 [[package]]
@@ -1979,12 +1989,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
+name = "time-core"
+version = "0.1.1"
+source = "git+https://github.com/saschagrunert/time?branch=v0.3.23-fix#22f9ac760e36ca965a7205056f719d5db8d153c1"
+
+[[package]]
 name = "time-macros"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
 dependencies = [
- "time-core",
+ "time-core 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.2.10"
+source = "git+https://github.com/saschagrunert/time?branch=v0.3.23-fix#22f9ac760e36ca965a7205056f719d5db8d153c1"
+dependencies = [
+ "time-core 0.1.1 (git+https://github.com/saschagrunert/time?branch=v0.3.23-fix)",
 ]
 
 [[package]]

--- a/conmon-rs/server/Cargo.toml
+++ b/conmon-rs/server/Cargo.toml
@@ -53,4 +53,8 @@ dashmap = "6.0.1"
 
 [dev-dependencies]
 mockall = "0.13.0"
-time = { version = "0.3.23", features = ["parsing"] }
+# Use this time-rs fork to fix the build issues with newer rust. It's identical
+# to v0.3.23 of the crate, except:
+# https://github.com/saschagrunert/time/commit/22f9ac760e36ca965a7205056f719d5db8d153c1
+# TODO: Remove when we can use newer Rust versions than v1.66.1
+time = { git = "https://github.com/saschagrunert/time", branch = "v0.3.23-fix", features = ["parsing"] }


### PR DESCRIPTION

#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
Use a fork of time-rs to fix the build for newer Rust versions.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed build for newer Rust versions.
```
