### PR TITLE
Remove double vendored sources from release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,6 @@ create-release-packages: release
 		echo "crate version and tag mismatch" ; \
 		exit 1 ; \
 	fi
-	cargo vendor -q && tar zcf $(PACKAGE_NAME)-vendor.tar.gz vendor && rm -rf vendor
 	git archive --format tar --prefix=conmonrs-$(CI_TAG)/ $(CI_TAG) | gzip >$(PACKAGE_NAME).tar.gz
 
 

--- a/release.md
+++ b/release.md
@@ -14,7 +14,6 @@ action](https://github.com/containers/conmon-rs/actions/workflows/release.yml)
 should run for that tag which attaches the vendored sources to the release, for
 example:
 
-- [conmonrs-v0.4.0-vendor.tar.gz](https://github.com/containers/conmon-rs/releases/download/v0.4.0/conmonrs-v0.4.0-vendor.tar.gz)
 - [conmonrs-v0.4.0.tar.gz](https://github.com/containers/conmon-rs/releases/download/v0.4.0/conmonrs-v0.4.0.tar.gz)
 
 Those sources have to be used to update the package in


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We already vendor the sources so we do not have to do it multiple times.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
