### PR TITLE
Disable dependabot for Rust

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,22 @@
 version: 2
 updates:
-- package-ecosystem: cargo
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "11:00"
-  open-pull-requests-limit: 10
-  labels:
-    - "release-note-none"
-  allow:
-  - dependency-type: direct
-  - dependency-type: indirect
-  groups:
-    opentelemetry:
-      patterns:
-        - "opentelemetry*"
-        - "tracing-opentelemetry"
+# TODO: does not support vendoring
+# - package-ecosystem: cargo
+#   directory: "/"
+#   schedule:
+#     interval: daily
+#     time: "11:00"
+#   open-pull-requests-limit: 10
+#   labels:
+#     - "release-note-none"
+#   allow:
+#   - dependency-type: direct
+#   - dependency-type: indirect
+#   groups:
+#     opentelemetry:
+#       patterns:
+#         - "opentelemetry*"
+#         - "tracing-opentelemetry"
 - package-ecosystem: gomod
   directory: "/"
   schedule:


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
Dependabot does not support vendored cargo, so we have to disable it for now.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
