### PR TITLE
Allow errors message from streaming server if wrong protocol is used

### DIFF
--- a/conmon-rs/server/src/streaming_server.rs
+++ b/conmon-rs/server/src/streaming_server.rs
@@ -15,7 +15,7 @@ use axum::{
     },
     http::StatusCode,
     response::IntoResponse,
-    routing::get,
+    routing::{get, post},
 };
 use conmon_common::conmon_capnp::conmon::CgroupManager;
 use futures::{
@@ -180,6 +180,10 @@ impl StreamingServer {
             .route(&Self::path_for(EXEC_PATH), get(Self::handle))
             .route(&Self::path_for(ATTACH_PATH), get(Self::handle))
             .route(&Self::path_for(PORT_FORWARD_PATH), get(Self::handle))
+            // for allowing proper error handling on wrong protocol usage (spdy instead of websocket)
+            .route(&Self::path_for(EXEC_PATH), post(Self::handle))
+            .route(&Self::path_for(ATTACH_PATH), post(Self::handle))
+            .route(&Self::path_for(PORT_FORWARD_PATH), post(Self::handle))
             .fallback(Self::fallback)
             .with_state(state)
             .layer(


### PR DESCRIPTION


#### What type of PR is this?


/kind bug



#### What this PR does / why we need it:
This allows to propagate an error message to the end user if spdy is being used instead of a websocket connection.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
