### PR TITLE
Add `--version-json` flag for JSON version output

### DIFF
--- a/conmon-rs/server/src/config.rs
+++ b/conmon-rs/server/src/config.rs
@@ -40,6 +40,20 @@ pub struct Config {
     /// Show version information, specify "full" for verbose output.
     version: Option<Verbosity>,
 
+    #[get_copy = "pub"]
+    #[arg(
+        default_missing_value("default"),
+        env(concat!(prefix!(), "VERSION_JSON")),
+        long("version-json"),
+        visible_alias("vj"),
+        short('j'),
+        num_args(0..=1),
+        value_enum,
+        value_name("VERBOSITY")
+    )]
+    /// Show version information as parsable JSON, specify "full" for verbose output.
+    version_json: Option<Verbosity>,
+
     #[get = "pub"]
     #[arg(
         default_value_t,

--- a/conmon-rs/server/src/server.rs
+++ b/conmon-rs/server/src/server.rs
@@ -82,6 +82,11 @@ impl Server {
             process::exit(0);
         }
 
+        if let Some(v) = server.config().version_json() {
+            Version::new(v == Verbosity::Full).print_json()?;
+            process::exit(0);
+        }
+
         if let Some(Commands::Pause {
             base_path,
             pod_id,


### PR DESCRIPTION


#### What type of PR is this?


/kind feature

#### What this PR does / why we need it:
Allowing to output the version in parsable JSON format.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
