### PR TITLE
Add GITHUB_TOKEN env support to get script

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -11,6 +11,7 @@ COMMIT=
 TAG=
 NO_EXEC=
 OUTPUT=conmonrs
+GITHUB_TOKEN=${GITHUB_TOKEN:-}
 
 usage() {
     printf "Usage: %s [ -t SHA ] [-l TAG ] [-a ARCH] [ -h ]\n\n" "$(basename "$0")"
@@ -88,7 +89,11 @@ verify_requirements() {
 }
 
 curl_retry() {
-    curl -sSfL --retry 5 --retry-delay 3 "$@"
+    ARGS=(-sSfL --retry 5 --retry-delay 3)
+    if [[ $GITHUB_TOKEN != "" && $1 == *".github.com/"* ]]; then
+        ARGS+=(--header "Authorization: Bearer $GITHUB_TOKEN")
+    fi
+    curl "${ARGS[@]}" "$@"
 }
 
 download_binary() {


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
We often hit 403 errors when running the get script in CI. To mitigate them, we now support the GITHUB_TOKEN environment variable and apply it correctly if required.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
See: https://github.com/cri-o/packaging/actions/runs/16485668216/job/46609790928
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `$GITHUB_TOKEN` environment variable support to `get` script.
```
