### PR TITLE
Fix memory leak in unbounded channels

### DIFF
--- a/conmon-rs/server/src/streams.rs
+++ b/conmon-rs/server/src/streams.rs
@@ -39,8 +39,8 @@ impl Streams {
     pub fn new(logger: SharedContainerLog, attach: SharedContainerAttach) -> Result<Self> {
         debug!("Creating new IO streams");
 
-        let (message_tx_stdout, message_rx_stdout) = async_channel::unbounded();
-        let (message_tx_stderr, message_rx_stderr) = async_channel::unbounded();
+        let (message_tx_stdout, message_rx_stdout) = async_channel::bounded(10);
+        let (message_tx_stderr, message_rx_stderr) = async_channel::bounded(10);
 
         Ok(Self {
             logger,

--- a/conmon-rs/server/src/terminal.rs
+++ b/conmon-rs/server/src/terminal.rs
@@ -119,7 +119,7 @@ impl Terminal {
 
         let attach_clone = self.attach.clone();
         let logger_clone = self.logger.clone();
-        let (message_tx, message_rx) = async_channel::unbounded();
+        let (message_tx, message_rx) = async_channel::bounded(10);
         self.message_rx = Some(message_rx);
 
         task::spawn({


### PR DESCRIPTION


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
Use bounded channels and only send data to them if they're not already full.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:
Fixes https://github.com/containers/conmon-rs/issues/2611
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed memory leak in unbounded channels.
```
