### PR TITLE
Fix deadlock when unwatching notify watchers

### DIFF
--- a/conmon-rs/server/src/oom_watcher.rs
+++ b/conmon-rs/server/src/oom_watcher.rs
@@ -309,12 +309,8 @@ impl OOMWatcher {
                 }
             }
         }
-        watcher
-            .unwatch(&memory_events_file_path)
-            .context("unwatch memory events file")?;
 
         debug!("Done watching for ooms");
-
         Ok(())
     }
 


### PR DESCRIPTION


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
The `unwatch` call can deadlock in specifics cases which cause test flakes in our CI. We now work around this issue by stopping the unwatch and let conmon-rs terminate correctly.


#### Which issue(s) this PR fixes:

Ref: https://github.com/notify-rs/notify/issues/463


#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Stop conmon-rs from hanging when inotify unwatching blocks. 
```
