### PR TITLE
Add support for `--log-driver=none`

### DIFF
--- a/conmon-rs/server/src/config.rs
+++ b/conmon-rs/server/src/config.rs
@@ -297,6 +297,9 @@ pub enum Verbosity {
 #[strum(serialize_all = "lowercase")]
 /// Available log drivers.
 pub enum LogDriver {
+    /// Use no log driver.
+    None,
+
     /// Use stdout as log driver.
     Stdout,
 

--- a/conmon-rs/server/src/server.rs
+++ b/conmon-rs/server/src/server.rs
@@ -186,6 +186,7 @@ impl Server {
         let registry = tracing_subscriber::registry().with(telemetry_layer);
 
         match self.config().log_driver() {
+            LogDriver::None => {}
             LogDriver::Stdout => {
                 let layer = tracing_subscriber::fmt::layer()
                     .with_target(true)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"sync"
 	"syscall"
@@ -432,16 +433,15 @@ func validateLogDriver(driver LogDriver) error {
 	return validateStringSlice(
 		"log driver",
 		string(driver),
+		string(LogDriverNone),
 		string(LogDriverStdout),
 		string(LogDriverSystemd),
 	)
 }
 
 func validateStringSlice(typ, given string, possibleValues ...string) error {
-	for _, possibleValue := range possibleValues {
-		if given == possibleValue {
-			return nil
-		}
+	if slices.Contains(possibleValues, given) {
+		return nil
 	}
 
 	return fmt.Errorf("%w: %s %q", errInvalidValue, typ, given)

--- a/pkg/client/consts.go
+++ b/pkg/client/consts.go
@@ -29,6 +29,9 @@ const (
 type LogDriver string
 
 const (
+	// LogDriverNone disables logging.
+	LogDriverNone LogDriver = "none"
+
 	// LogDriverStdout is the log driver printing to stdio.
 	LogDriverStdout LogDriver = "stdout"
 


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
This allows to disable logging to save memory.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
Refers to https://github.com/cri-o/cri-o/pull/9388
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added support for `--log-driver=none` to disable logging.
```
