### PR TITLE
Fix deadlocks in child reaper and OOM watcher

### DIFF
--- a/conmon-rs/server/src/child_reaper.rs
+++ b/conmon-rs/server/src/child_reaper.rs
@@ -364,10 +364,11 @@ impl ReapableChild {
                 });
 
                 let closure = async {
-                    if let Ok(code) = wait_for_exit_code.await {
+                    let (code, oom) = tokio::join!(wait_for_exit_code, oom_rx.recv());
+                    if let Ok(code) = code {
                         exit_code = code;
                     }
-                    if let Some(event) = oom_rx.recv().await {
+                    if let Some(event) = oom {
                         oomed = event.oom;
                     }
                 };


### PR DESCRIPTION
This PR fixes two separate deadlocks that caused test timeouts in CI.

## Issues Fixed

### 1. Child reaper exit handling deadlock
Commit 5cc4662eb accidentally changed from concurrent waiting (`tokio::join!`) to sequential awaits. After a process exited, the code would block on `oom_rx.recv()` waiting for an OOM event that would never arrive in the normal case, causing indefinite hangs.

### 2. OOM watcher callback deadlock
The notify file watcher callback used `block_on(tx.send().await)`, which could deadlock when file events occurred during watcher setup before the receiver started polling. The callback thread would block waiting for channel space while the main task was blocked in watcher setup.

## Changes

- Restored `tokio::join!` in `child_reaper.rs` to wait for exit code and OOM events concurrently
- Changed OOM watcher callback to use `try_send()` instead of blocking `send().await` to prevent deadlocks

## Testing

- All 54 integration tests pass locally and in CI
- Stress tests with 10 concurrent ExecSync operations complete successfully
- Tests complete in ~40 seconds (previously timing out at 5 minutes)

Fixes: 5cc4662eb ("Skip access events")