### PR TITLE
Fix cosign sign-blob with --bundle flag for v3 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,7 @@ jobs:
         run: |
           cd ${{ github.sha }}
           cosign sign-blob -y conmonrs \
+            --bundle conmonrs.bundle \
             --output-signature conmonrs.sig \
             --output-certificate conmonrs.cert
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
@@ -168,6 +169,7 @@ jobs:
         run: |
           cd ${{ github.sha }}
           cosign sign-blob -y conmonrs.${{ matrix.arch }} \
+            --bundle conmonrs.${{ matrix.arch }}.bundle \
             --output-signature conmonrs.${{ matrix.arch }}.sig \
             --output-certificate conmonrs.${{ matrix.arch }}.cert
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

Fixes the CI failures in static binary build jobs caused by the recent update to `sigstore/cosign-installer` v4.0.0. This version installs Cosign v3, which introduces a breaking change requiring the `--bundle` flag when using `cosign sign-blob`.

This PR adds the `--bundle` flag to both signing steps:
- `release-static` job: creates `conmonrs.bundle`
- `build-static` job: creates `conmonrs.${{ matrix.arch }}.bundle`

The bundle files will be uploaded alongside the signature and certificate files as artifacts.

#### Which issue(s) this PR fixes:

Fixes https://github.com/containers/conmon-rs/actions/runs/19429313842/job/55584181569

#### Special notes for your reviewer:

The breaking change was introduced in cosign-installer v4.0.0 (merged in #2830). According to the [v4.0.0 release notes](https://github.com/sigstore/cosign-installer/releases/tag/v4.0.0), Cosign v3 requires the `--bundle` flag for `sign-blob` operations.

#### Does this PR introduce a user-facing change?

```release-note
None
```