### PR TITLE
Use persistent RPC connection in Go client

### DIFF
--- a/pkg/client/attach.go
+++ b/pkg/client/attach.go
@@ -104,20 +104,12 @@ func (c *ConmonClient) AttachContainer(ctx context.Context, cfg *AttachConfig) e
 		defer span.End()
 	}
 
-	conn, err := c.newRPCConn()
+	rpcClient, err := c.client(ctx)
 	if err != nil {
-		return fmt.Errorf("create RPC connection: %w", err)
+		return fmt.Errorf("create RPC client: %w", err)
 	}
 
-	defer func() {
-		if err := conn.Close(); err != nil {
-			c.logger.Errorf("Unable to close connection: %v", err)
-		}
-	}()
-
-	client := proto.Conmon(conn.Bootstrap(ctx))
-
-	future, free := client.AttachContainer(ctx, func(p proto.Conmon_attachContainer_Params) error {
+	future, free := rpcClient.AttachContainer(ctx, func(p proto.Conmon_attachContainer_Params) error {
 		req, err := p.NewRequest()
 		if err != nil {
 			return fmt.Errorf("create request: %w", err)
@@ -144,6 +136,8 @@ func (c *ConmonClient) AttachContainer(ctx context.Context, cfg *AttachConfig) e
 
 	result, err := future.Struct()
 	if err != nil {
+		c.resetConn()
+
 		return fmt.Errorf("create result: %w", err)
 	}
 
@@ -494,16 +488,12 @@ func (c *ConmonClient) SetWindowSizeContainer(ctx context.Context, cfg *SetWindo
 		return errTerminalSizeNil
 	}
 
-	conn, err := c.newRPCConn()
+	rpcClient, err := c.client(ctx)
 	if err != nil {
-		return fmt.Errorf("create RPC connection: %w", err)
+		return fmt.Errorf("create RPC client: %w", err)
 	}
 
-	defer conn.Close()
-
-	client := proto.Conmon(conn.Bootstrap(ctx))
-
-	future, free := client.SetWindowSizeContainer(ctx, func(p proto.Conmon_setWindowSizeContainer_Params) error {
+	future, free := rpcClient.SetWindowSizeContainer(ctx, func(p proto.Conmon_setWindowSizeContainer_Params) error {
 		req, err := p.NewRequest()
 		if err != nil {
 			return fmt.Errorf("create request: %w", err)
@@ -526,6 +516,8 @@ func (c *ConmonClient) SetWindowSizeContainer(ctx context.Context, cfg *SetWindo
 
 	result, err := future.Struct()
 	if err != nil {
+		c.resetConn()
+
 		return fmt.Errorf("create result: %w", err)
 	}
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -55,6 +55,9 @@ type ConmonClient struct {
 	tracer         trace.Tracer
 	serverVersion  semver.Version
 	cgroupManager  CgroupManager
+	connMu         sync.Mutex
+	conn           *rpc.Conn
+	rpcClient      proto.Conmon
 }
 
 // ConmonServerConfig is the configuration for the conmon server instance.
@@ -516,13 +519,34 @@ func defaultContext() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), defaultTimeout)
 }
 
-func (c *ConmonClient) newRPCConn() (*rpc.Conn, error) {
-	socketConn, err := DialLongSocket("unix", c.socket())
-	if err != nil {
-		return nil, fmt.Errorf("dial long socket: %w", err)
+func (c *ConmonClient) client(ctx context.Context) (proto.Conmon, error) {
+	c.connMu.Lock()
+	defer c.connMu.Unlock()
+
+	if c.conn != nil {
+		return c.rpcClient, nil
 	}
 
-	return rpc.NewConn(rpc.NewStreamTransport(socketConn), nil), nil
+	socketConn, err := DialLongSocket("unix", c.socket())
+	if err != nil {
+		return proto.Conmon{}, fmt.Errorf("dial long socket: %w", err)
+	}
+
+	c.conn = rpc.NewConn(rpc.NewStreamTransport(socketConn), nil)
+	c.rpcClient = proto.Conmon(c.conn.Bootstrap(ctx))
+
+	return c.rpcClient, nil
+}
+
+func (c *ConmonClient) resetConn() {
+	c.connMu.Lock()
+	defer c.connMu.Unlock()
+
+	if c.conn != nil {
+		c.conn.Close()
+		c.conn = nil
+		c.rpcClient = proto.Conmon{}
+	}
 }
 
 // DialLongSocket is a wrapper around net.DialUnix.
@@ -603,16 +627,12 @@ func (c *ConmonClient) Version(
 		defer span.End()
 	}
 
-	conn, err := c.newRPCConn()
+	rpcClient, err := c.client(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("create RPC connection: %w", err)
+		return nil, fmt.Errorf("create RPC client: %w", err)
 	}
 
-	defer conn.Close()
-
-	client := proto.Conmon(conn.Bootstrap(ctx))
-
-	future, free := client.Version(ctx, func(p proto.Conmon_version_Params) error {
+	future, free := rpcClient.Version(ctx, func(p proto.Conmon_version_Params) error {
 		req, err := p.NewRequest()
 		if err != nil {
 			return fmt.Errorf("create request: %w", err)
@@ -635,6 +655,8 @@ func (c *ConmonClient) Version(
 
 	result, err := future.Struct()
 	if err != nil {
+		c.resetConn()
+
 		return nil, fmt.Errorf("create result: %w", err)
 	}
 
@@ -813,16 +835,12 @@ func (c *ConmonClient) CreateContainer(
 		defer span.End()
 	}
 
-	conn, err := c.newRPCConn()
+	rpcClient, err := c.client(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("create RPC connection: %w", err)
+		return nil, fmt.Errorf("create RPC client: %w", err)
 	}
 
-	defer conn.Close()
-
-	client := proto.Conmon(conn.Bootstrap(ctx))
-
-	future, free := client.CreateContainer(ctx, func(p proto.Conmon_createContainer_Params) error {
+	future, free := rpcClient.CreateContainer(ctx, func(p proto.Conmon_createContainer_Params) error {
 		req, err := p.NewRequest()
 		if err != nil {
 			return fmt.Errorf("create request: %w", err)
@@ -887,6 +905,8 @@ func (c *ConmonClient) CreateContainer(
 
 	result, err := future.Struct()
 	if err != nil {
+		c.resetConn()
+
 		return nil, fmt.Errorf("create result: %w", err)
 	}
 
@@ -947,15 +967,12 @@ func (c *ConmonClient) ExecSyncContainer(ctx context.Context, cfg *ExecSyncConfi
 		defer span.End()
 	}
 
-	conn, err := c.newRPCConn()
+	rpcClient, err := c.client(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("create RPC connection: %w", err)
+		return nil, fmt.Errorf("create RPC client: %w", err)
 	}
-	defer conn.Close()
 
-	client := proto.Conmon(conn.Bootstrap(ctx))
-
-	future, free := client.ExecSyncContainer(ctx, func(p proto.Conmon_execSyncContainer_Params) error {
+	future, free := rpcClient.ExecSyncContainer(ctx, func(p proto.Conmon_execSyncContainer_Params) error {
 		req, err := p.NewRequest()
 		if err != nil {
 			return fmt.Errorf("create request: %w", err)
@@ -989,6 +1006,8 @@ func (c *ConmonClient) ExecSyncContainer(ctx context.Context, cfg *ExecSyncConfi
 
 	result, err := future.Struct()
 	if err != nil {
+		c.resetConn()
+
 		return nil, fmt.Errorf("create result: %w", err)
 	}
 
@@ -1066,6 +1085,8 @@ func (c *ConmonClient) Shutdown() error {
 		return true
 	})
 
+	c.resetConn()
+
 	pid := int(c.serverPID)
 	if err := syscall.Kill(pid, syscall.SIGINT); err != nil {
 		// Process does not exist any more, it might be manually killed.
@@ -1115,16 +1136,12 @@ func (c *ConmonClient) ReopenLogContainer(ctx context.Context, cfg *ReopenLogCon
 		defer span.End()
 	}
 
-	conn, err := c.newRPCConn()
+	rpcClient, err := c.client(ctx)
 	if err != nil {
-		return fmt.Errorf("create RPC connection: %w", err)
+		return fmt.Errorf("create RPC client: %w", err)
 	}
 
-	defer conn.Close()
-
-	client := proto.Conmon(conn.Bootstrap(ctx))
-
-	future, free := client.ReopenLogContainer(ctx, func(p proto.Conmon_reopenLogContainer_Params) error {
+	future, free := rpcClient.ReopenLogContainer(ctx, func(p proto.Conmon_reopenLogContainer_Params) error {
 		req, err := p.NewRequest()
 		if err != nil {
 			return fmt.Errorf("create request: %w", err)
@@ -1144,6 +1161,8 @@ func (c *ConmonClient) ReopenLogContainer(ctx context.Context, cfg *ReopenLogCon
 
 	result, err := future.Struct()
 	if err != nil {
+		c.resetConn()
+
 		return fmt.Errorf("create result: %w", err)
 	}
 
@@ -1270,16 +1289,12 @@ func (c *ConmonClient) CreateNamespaces(
 		return nil, fmt.Errorf("requires at least %v: %w", minVersion, ErrUnsupported)
 	}
 
-	conn, err := c.newRPCConn()
+	rpcClient, err := c.client(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("create RPC connection: %w", err)
+		return nil, fmt.Errorf("create RPC client: %w", err)
 	}
 
-	defer conn.Close()
-
-	client := proto.Conmon(conn.Bootstrap(ctx))
-
-	future, free := client.CreateNamespaces(ctx, func(p proto.Conmon_createNamespaces_Params) error {
+	future, free := rpcClient.CreateNamespaces(ctx, func(p proto.Conmon_createNamespaces_Params) error {
 		req, err := p.NewRequest()
 		if err != nil {
 			return fmt.Errorf("create request: %w", err)
@@ -1355,6 +1370,8 @@ func (c *ConmonClient) CreateNamespaces(
 
 	result, err := future.Struct()
 	if err != nil {
+		c.resetConn()
+
 		return nil, fmt.Errorf("create result: %w", err)
 	}
 
@@ -1462,15 +1479,12 @@ func (c *ConmonClient) ServeExecContainer(
 		defer span.End()
 	}
 
-	conn, err := c.newRPCConn()
+	rpcClient, err := c.client(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("create RPC connection: %w", err)
+		return nil, fmt.Errorf("create RPC client: %w", err)
 	}
-	defer conn.Close()
 
-	client := proto.Conmon(conn.Bootstrap(ctx))
-
-	future, free := client.ServeExecContainer(ctx, func(p proto.Conmon_serveExecContainer_Params) error {
+	future, free := rpcClient.ServeExecContainer(ctx, func(p proto.Conmon_serveExecContainer_Params) error {
 		req, err := p.NewRequest()
 		if err != nil {
 			return fmt.Errorf("create request: %w", err)
@@ -1501,6 +1515,8 @@ func (c *ConmonClient) ServeExecContainer(
 
 	result, err := future.Struct()
 	if err != nil {
+		c.resetConn()
+
 		return nil, fmt.Errorf("create result: %w", err)
 	}
 
@@ -1554,15 +1570,12 @@ func (c *ConmonClient) ServeAttachContainer(
 		defer span.End()
 	}
 
-	conn, err := c.newRPCConn()
+	rpcClient, err := c.client(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("create RPC connection: %w", err)
+		return nil, fmt.Errorf("create RPC client: %w", err)
 	}
-	defer conn.Close()
 
-	client := proto.Conmon(conn.Bootstrap(ctx))
-
-	future, free := client.ServeAttachContainer(ctx, func(p proto.Conmon_serveAttachContainer_Params) error {
+	future, free := rpcClient.ServeAttachContainer(ctx, func(p proto.Conmon_serveAttachContainer_Params) error {
 		req, err := p.NewRequest()
 		if err != nil {
 			return fmt.Errorf("create request: %w", err)
@@ -1586,6 +1599,8 @@ func (c *ConmonClient) ServeAttachContainer(
 
 	result, err := future.Struct()
 	if err != nil {
+		c.resetConn()
+
 		return nil, fmt.Errorf("create result: %w", err)
 	}
 
@@ -1624,15 +1639,12 @@ func (c *ConmonClient) ServePortForwardContainer(
 		defer span.End()
 	}
 
-	conn, err := c.newRPCConn()
+	rpcClient, err := c.client(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("create RPC connection: %w", err)
+		return nil, fmt.Errorf("create RPC client: %w", err)
 	}
-	defer conn.Close()
 
-	client := proto.Conmon(conn.Bootstrap(ctx))
-
-	future, free := client.ServePortForwardContainer(ctx, func(p proto.Conmon_servePortForwardContainer_Params) error {
+	future, free := rpcClient.ServePortForwardContainer(ctx, func(p proto.Conmon_servePortForwardContainer_Params) error {
 		req, err := p.NewRequest()
 		if err != nil {
 			return fmt.Errorf("create request: %w", err)
@@ -1652,6 +1664,8 @@ func (c *ConmonClient) ServePortForwardContainer(
 
 	result, err := future.Struct()
 	if err != nil {
+		c.resetConn()
+
 		return nil, fmt.Errorf("create result: %w", err)
 	}
 

--- a/pkg/client/remote_fds.go
+++ b/pkg/client/remote_fds.go
@@ -137,20 +137,12 @@ func (c *ConmonClient) RemoteFDs(ctx context.Context) (*RemoteFDs, error) {
 		defer span.End()
 	}
 
-	conn, err := c.newRPCConn()
+	rpcClient, err := c.client(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("create RPC connection: %w", err)
+		return nil, fmt.Errorf("create RPC client: %w", err)
 	}
 
-	defer func() {
-		if err := conn.Close(); err != nil {
-			c.logger.Errorf("Unable to close connection: %v", err)
-		}
-	}()
-
-	client := proto.Conmon(conn.Bootstrap(ctx))
-
-	future, free := client.StartFdSocket(ctx, func(p proto.Conmon_startFdSocket_Params) error {
+	future, free := rpcClient.StartFdSocket(ctx, func(p proto.Conmon_startFdSocket_Params) error {
 		req, err := p.NewRequest()
 		if err != nil {
 			return fmt.Errorf("create request: %w", err)
@@ -166,6 +158,8 @@ func (c *ConmonClient) RemoteFDs(ctx context.Context) (*RemoteFDs, error) {
 
 	result, err := future.Struct()
 	if err != nil {
+		c.resetConn()
+
 		return nil, fmt.Errorf("create result: %w", err)
 	}
 


### PR DESCRIPTION
/kind feature

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Maintains a single Cap'n Proto RPC connection per `ConmonClient` instead of creating and tearing down a new Unix socket connection for every RPC call. The connection is lazily established on first use and reset on RPC-level errors so the next call reconnects.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The `defer free()` pattern and stdout/stderr copy in `ExecSyncContainer` remain unchanged since message lifecycle is independent of connection lifecycle.

#### Does this PR introduce a user-facing change?

```release-note
Use a persistent Cap'n Proto RPC connection per ConmonClient instead of reconnecting on every call.
```