### PR TITLE
Avoid blocking file removal in Terminal::drop

### DIFF
--- a/conmon-rs/server/src/terminal.rs
+++ b/conmon-rs/server/src/terminal.rs
@@ -267,13 +267,16 @@ impl Terminal {
 
 impl Drop for Terminal {
     fn drop(&mut self) {
-        if let Err(e) = std::fs::remove_file(self.path()) {
-            trace!(
-                "Unable to remove socket file path {}: {}",
-                self.path().display(),
-                e
-            )
-        }
+        let path = self.path().to_path_buf();
+        task::spawn(async move {
+            if let Err(e) = fs::remove_file(&path).await {
+                trace!(
+                    "Unable to remove socket file path {}: {}",
+                    path.display(),
+                    e
+                )
+            }
+        });
     }
 }
 


### PR DESCRIPTION
/kind bug

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Replaces synchronous `std::fs::remove_file()` in `Terminal::drop` with an async `tokio::fs::remove_file()` spawned via `task::spawn`. Since `Drop::drop` is synchronous, the blocking call could stall the Tokio executor thread.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```