### PR TITLE
perf: channel-based logging, sync I/O

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,7 +395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -621,9 +621,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -753,7 +753,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1315,7 +1315,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1462,7 +1462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1518,7 +1518,7 @@ dependencies = [
  "fastrand",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2030,7 +2030,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/conmon-rs/server/src/attach.rs
+++ b/conmon-rs/server/src/attach.rs
@@ -39,8 +39,8 @@ pub struct SharedContainerAttach {
 
 impl Default for SharedContainerAttach {
     fn default() -> Self {
-        let (read_half_tx, read_half_rx) = broadcast::channel(16);
-        let (write_half_tx, _) = broadcast::channel(16);
+        let (read_half_tx, read_half_rx) = broadcast::channel(32);
+        let (write_half_tx, _) = broadcast::channel(32);
         Self {
             read_half_rx,
             read_half_tx,

--- a/conmon-rs/server/src/container_io.rs
+++ b/conmon-rs/server/src/container_io.rs
@@ -283,19 +283,13 @@ impl ContainerIO {
 
                 Ok(n) => {
                     trace!("Read {} bytes", n);
-                    let data = &buf[..n];
+                    let data_arc: Arc<[u8]> = Arc::from(&buf[..n]);
 
-                    let mut locked_logger = logger.write().await;
-                    locked_logger
-                        .write(pipe, data)
+                    logger
+                        .send(pipe, Arc::clone(&data_arc))
                         .await
-                        .context("write to log file")?;
+                        .context("send to log writer")?;
 
-                    // Use Arc to share data between attach and message channel
-                    // without cloning the buffer contents
-                    let data_arc: Arc<[u8]> = Arc::from(data);
-
-                    // Only send to attach if there are active attach clients
                     if attach.has_readers() {
                         attach
                             .write(Message::Data(Arc::clone(&data_arc), pipe))

--- a/conmon-rs/server/src/container_log/cri.rs
+++ b/conmon-rs/server/src/container_log/cri.rs
@@ -3,13 +3,12 @@
 use crate::container_io::Pipe;
 use anyhow::{Context, Result};
 use memchr::memchr;
+use std::fs::{File, OpenOptions};
+use std::io::{BufWriter, Write};
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 use time::{OffsetDateTime, format_description::well_known::Rfc3339};
-use tokio::{
-    fs::{File, OpenOptions},
-    io::{AsyncBufRead, AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter},
-};
 use tracing::{debug, trace};
 
 #[derive(Debug)]
@@ -29,6 +28,9 @@ pub struct CriLogger {
 
     /// Reusable buffer for line reading to reduce allocations
     line_buf: Vec<u8>,
+
+    /// Reusable buffer for composing full log lines before writing
+    write_buf: Vec<u8>,
 
     /// Cached timestamp string to avoid repeated formatting
     cached_timestamp: String,
@@ -65,27 +67,22 @@ impl CriLogger {
             file: None,
             max_log_size,
             bytes_written: 0,
-            line_buf: Vec::with_capacity(256), // Pre-allocate for typical log lines
+            line_buf: Vec::with_capacity(256),
+            write_buf: Vec::with_capacity(512),
             cached_timestamp: String::new(),
             last_timestamp_update: Instant::now(),
         })
     }
 
-    /// Asynchronously initialize the CRI logger.
-    pub async fn init(&mut self) -> Result<()> {
+    /// Initialize the CRI logger.
+    pub fn init(&mut self) -> Result<()> {
         debug!("Initializing CRI logger in path {}", self.path().display());
-        self.set_file(Self::open(self.path()).await?.into());
+        self.set_file(Self::open(self.path())?.into());
         Ok(())
     }
 
-    /// Write the contents of the provided reader into the file logger.
-    pub async fn write<T>(&mut self, pipe: Pipe, bytes: T) -> Result<()>
-    where
-        T: AsyncBufRead + Unpin,
-    {
-        let mut reader = BufReader::new(bytes);
-
-        // Update cached timestamp if it's been more than 100ms or if empty (first use)
+    /// Write the contents of the provided data into the file logger.
+    pub fn write(&mut self, pipe: Pipe, data: &[u8]) -> Result<()> {
         let now = Instant::now();
         if self.cached_timestamp.is_empty()
             || now.duration_since(self.last_timestamp_update) >= Duration::from_millis(100)
@@ -97,29 +94,46 @@ impl CriLogger {
             self.last_timestamp_update = now;
         }
 
-        let min_log_len = self
-            .cached_timestamp
-            .len()
-            .checked_add(10) // len of " stdout " + "P "
-            .context("min log line len exceeds usize")?;
+        let pipe_tag = match pipe {
+            Pipe::StdOut => &b" stdout "[..],
+            Pipe::StdErr => &b" stderr "[..],
+        };
 
+        let mut remaining = data;
         loop {
-            // Read the line - reuse buffer with clear instead of allocating
-            self.line_buf.clear();
-            if self.line_buf.capacity() < min_log_len {
-                self.line_buf
-                    .reserve(min_log_len - self.line_buf.capacity());
-            }
-            let (read, partial) = Self::read_line(&mut reader, &mut self.line_buf).await?;
-
-            if read == 0 {
+            if remaining.is_empty() {
                 break;
             }
 
-            let mut bytes_to_be_written = read + min_log_len;
+            self.line_buf.clear();
+            let (partial, consumed) = match memchr(b'\n', remaining) {
+                Some(i) => {
+                    self.line_buf.extend_from_slice(&remaining[..=i]);
+                    (false, i + 1)
+                }
+                None => {
+                    self.line_buf.extend_from_slice(remaining);
+                    (true, remaining.len())
+                }
+            };
+            remaining = &remaining[consumed..];
+
+            // Compose the full log line into write_buf
+            self.write_buf.clear();
+            self.write_buf
+                .extend_from_slice(self.cached_timestamp.as_bytes());
+            self.write_buf.extend_from_slice(pipe_tag);
             if partial {
-                bytes_to_be_written += 1; // the added newline
+                self.write_buf.extend_from_slice(b"P ");
+            } else {
+                self.write_buf.extend_from_slice(b"F ");
             }
+            self.write_buf.extend_from_slice(&self.line_buf);
+            if partial {
+                self.write_buf.push(b'\n');
+            }
+
+            let bytes_to_be_written = self.write_buf.len();
 
             let mut new_bytes_written = self
                 .bytes_written()
@@ -128,13 +142,12 @@ impl CriLogger {
 
             if new_bytes_written == 0 {
                 self.reopen()
-                    .await
                     .context("reopen logs because of overflowing bytes_written")?;
             }
 
             if let Some(max_log_size) = self.max_log_size() {
                 trace!(
-                    "Verifying log size: max_log_size = {}, bytes_written = {},  bytes_to_be_written = {}, new_bytes_written = {}",
+                    "Verifying log size: max_log_size = {}, bytes_written = {}, bytes_to_be_written = {}, new_bytes_written = {}",
                     max_log_size,
                     self.bytes_written(),
                     bytes_to_be_written,
@@ -144,67 +157,42 @@ impl CriLogger {
                 if new_bytes_written > max_log_size {
                     new_bytes_written = 0;
                     self.reopen()
-                        .await
                         .context("reopen logs because of exceeded size")?;
                 }
             }
 
-            // Write the timestamp
             let file = self.file.as_mut().context(Self::ERR_UNINITIALIZED)?;
-            file.write_all(self.cached_timestamp.as_bytes()).await?;
-
-            // Add the pipe name
-            match pipe {
-                Pipe::StdOut => file.write_all(b" stdout ").await,
-                Pipe::StdErr => file.write_all(b" stderr ").await,
-            }?;
-
-            // Output log tag for partial or newline
-            if partial {
-                file.write_all(b"P ").await?;
-            } else {
-                file.write_all(b"F ").await?;
-            }
-
-            // Output the actual contents
-            file.write_all(&self.line_buf).await?;
-
-            // Output a newline for partial
-            if partial {
-                file.write_all(b"\n").await?;
-            }
+            file.write_all(&self.write_buf)?;
 
             self.set_bytes_written(new_bytes_written);
             trace!("Wrote log line of length {}", bytes_to_be_written);
         }
 
-        self.flush().await
+        self.flush()
     }
 
     /// Reopen the container log file.
-    pub async fn reopen(&mut self) -> Result<()> {
+    pub fn reopen(&mut self) -> Result<()> {
         debug!("Reopen container log {}", self.path().display());
         self.file
             .as_mut()
             .context(Self::ERR_UNINITIALIZED)?
             .get_ref()
-            .sync_all()
-            .await?;
-        self.init().await
+            .sync_all()?;
+        self.init()
     }
 
     /// Ensures that all content is written to disk.
-    pub async fn flush(&mut self) -> Result<()> {
+    pub fn flush(&mut self) -> Result<()> {
         self.file
             .as_mut()
             .context(Self::ERR_UNINITIALIZED)?
             .flush()
-            .await
             .context("flush file writer")
     }
 
     /// Open the provided path with the default options.
-    async fn open<T: AsRef<Path>>(path: T) -> Result<BufWriter<File>> {
+    fn open<T: AsRef<Path>>(path: T) -> Result<BufWriter<File>> {
         Ok(BufWriter::new(
             OpenOptions::new()
                 .create(true)
@@ -213,30 +201,8 @@ impl CriLogger {
                 .write(true)
                 .mode(0o600)
                 .open(&path)
-                .await
                 .with_context(|| format!("open log file path '{}'", path.as_ref().display()))?,
         ))
-    }
-
-    async fn read_line<T>(r: &mut BufReader<T>, buf: &mut Vec<u8>) -> Result<(usize, bool)>
-    where
-        T: AsyncBufRead + Unpin,
-    {
-        let (partial, read) = {
-            let available = r.fill_buf().await?;
-            match memchr(b'\n', available) {
-                Some(i) => {
-                    buf.extend_from_slice(&available[..=i]);
-                    (false, i + 1)
-                }
-                None => {
-                    buf.extend_from_slice(available);
-                    (true, available.len())
-                }
-            }
-        };
-        r.consume(read);
-        Ok((read, partial))
     }
 }
 
@@ -247,17 +213,16 @@ mod tests {
     use tempfile::NamedTempFile;
     use time::{OffsetDateTime, format_description::well_known::Rfc3339};
 
-    #[tokio::test]
-    async fn write_stdout_success() -> Result<()> {
+    #[test]
+    fn write_stdout_success() -> Result<()> {
         let buffer = "this is a line\nand another line\n";
-        let bytes = buffer.as_bytes();
 
         let file = NamedTempFile::new()?;
         let path = file.path();
         let mut sut = CriLogger::new(path, None)?;
-        sut.init().await?;
+        sut.init()?;
 
-        sut.write(Pipe::StdOut, bytes).await?;
+        sut.write(Pipe::StdOut, buffer.as_bytes())?;
 
         let res = fs::read_to_string(path)?;
         assert!(res.contains(" stdout F this is a line"));
@@ -268,19 +233,17 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn write_stdout_stderr_success() -> Result<()> {
+    #[test]
+    fn write_stdout_stderr_success() -> Result<()> {
         let buffer = "a\nb\nc\n";
-        let bytes1 = buffer.as_bytes();
-        let bytes2 = buffer.as_bytes();
 
         let file = NamedTempFile::new()?;
         let path = file.path();
         let mut sut = CriLogger::new(path, None)?;
-        sut.init().await?;
+        sut.init()?;
 
-        sut.write(Pipe::StdOut, bytes1).await?;
-        sut.write(Pipe::StdErr, bytes2).await?;
+        sut.write(Pipe::StdOut, buffer.as_bytes())?;
+        sut.write(Pipe::StdErr, buffer.as_bytes())?;
 
         let res = fs::read_to_string(path)?;
         assert!(res.contains(" stdout F a"));
@@ -292,17 +255,16 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn write_reopen() -> Result<()> {
+    #[test]
+    fn write_reopen() -> Result<()> {
         let buffer = "a\nb\nc\nd\ne\nf\n";
-        let bytes = buffer.as_bytes();
 
         let file = NamedTempFile::new()?;
         let path = file.path();
         let mut sut = CriLogger::new(path, Some(150))?;
-        sut.init().await?;
+        sut.init()?;
 
-        sut.write(Pipe::StdOut, bytes).await?;
+        sut.write(Pipe::StdOut, buffer.as_bytes())?;
 
         let res = fs::read_to_string(path)?;
         assert!(!res.contains(" stdout F a"));
@@ -314,16 +276,15 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn write_multi_reopen() -> Result<()> {
+    #[test]
+    fn write_multi_reopen() -> Result<()> {
         let file = NamedTempFile::new()?;
         let path = file.path();
         let mut sut = CriLogger::new(path, Some(150))?;
-        sut.init().await?;
+        sut.init()?;
 
-        sut.write(Pipe::StdOut, "abcd\nabcd\nabcd\n".as_bytes())
-            .await?;
-        sut.write(Pipe::StdErr, "a\nb\nc\n".as_bytes()).await?;
+        sut.write(Pipe::StdOut, "abcd\nabcd\nabcd\n".as_bytes())?;
+        sut.write(Pipe::StdErr, "a\nb\nc\n".as_bytes())?;
 
         let res = fs::read_to_string(path)?;
         assert!(!res.contains(" stdout "));
@@ -333,10 +294,10 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn init_failure() -> Result<()> {
+    #[test]
+    fn init_failure() -> Result<()> {
         let mut sut = CriLogger::new("/file/does/not/exist", None)?;
-        assert!(sut.init().await.is_err());
+        assert!(sut.init().is_err());
         Ok(())
     }
 }

--- a/conmon-rs/server/src/container_log/journald.rs
+++ b/conmon-rs/server/src/container_log/journald.rs
@@ -1,10 +1,6 @@
 use crate::{container_io::Pipe, journal::Journal};
 use anyhow::{Context, Result};
 use std::io::Write;
-use tokio::{
-    io::{AsyncBufRead, AsyncBufReadExt},
-    task,
-};
 use tracing::debug;
 
 #[derive(Debug)]
@@ -15,30 +11,22 @@ impl JournaldLogger {
         Ok(Self)
     }
 
-    pub async fn init(&mut self) -> Result<()> {
+    pub fn init(&mut self) -> Result<()> {
         debug!("Initializing journald logger");
         Ok(())
     }
 
-    pub async fn write<T>(&mut self, _: Pipe, mut bytes: T) -> Result<()>
-    where
-        T: AsyncBufRead + Unpin,
-    {
-        let mut line_buf = String::new();
-        while bytes.read_line(&mut line_buf).await? > 0 {
-            let line = std::mem::take(&mut line_buf);
-            task::spawn_blocking(move || {
-                Journal
-                    .write_all(line.as_bytes())
-                    .context("write to journal")
-            })
-            .await
-            .context("journal spawn_blocking")??;
+    pub fn write(&mut self, _: Pipe, data: &[u8]) -> Result<()> {
+        let text = String::from_utf8_lossy(data);
+        for line in text.lines() {
+            Journal
+                .write_all(line.as_bytes())
+                .context("write to journal")?;
         }
         Ok(())
     }
 
-    pub async fn reopen(&mut self) -> Result<()> {
+    pub fn reopen(&mut self) -> Result<()> {
         debug!("Reopen journald log");
         Ok(())
     }
@@ -47,39 +35,43 @@ impl JournaldLogger {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Cursor;
 
-    #[tokio::test]
-    async fn test_journald_logger_new() {
+    #[test]
+    fn test_journald_logger_new() {
         JournaldLogger::new(Some(1000)).unwrap();
     }
 
-    #[tokio::test]
-    async fn test_journald_logger_init() {
+    #[test]
+    fn test_journald_logger_init() {
         let mut logger = JournaldLogger::new(Some(1000)).unwrap();
-        assert!(logger.init().await.is_ok());
+        assert!(logger.init().is_ok());
     }
 
-    #[tokio::test]
-    async fn test_journald_logger_write() {
+    #[test]
+    fn test_journald_logger_write() {
         let mut logger = JournaldLogger::new(Some(1000)).unwrap();
-        logger.init().await.unwrap();
+        logger.init().unwrap();
 
-        let cursor = Cursor::new(b"Test log message\n".to_vec());
-        assert!(logger.write(Pipe::StdOut, cursor).await.is_ok());
+        assert!(logger.write(Pipe::StdOut, b"Test log message\n").is_ok());
     }
 
-    #[tokio::test]
-    async fn test_journald_logger_reopen() {
+    #[test]
+    fn test_journald_logger_reopen() {
         let mut logger = JournaldLogger::new(Some(1000)).unwrap();
-        logger.init().await.unwrap();
+        logger.init().unwrap();
 
-        let cursor = Cursor::new(b"Test log message before reopen\n".to_vec());
-        assert!(logger.write(Pipe::StdOut, cursor).await.is_ok());
+        assert!(
+            logger
+                .write(Pipe::StdOut, b"Test log message before reopen\n")
+                .is_ok()
+        );
 
-        assert!(logger.reopen().await.is_ok());
+        assert!(logger.reopen().is_ok());
 
-        let cursor = Cursor::new(b"Test log message after reopen\n".to_vec());
-        assert!(logger.write(Pipe::StdOut, cursor).await.is_ok());
+        assert!(
+            logger
+                .write(Pipe::StdOut, b"Test log message after reopen\n")
+                .is_ok()
+        );
     }
 }

--- a/conmon-rs/server/src/container_log/json.rs
+++ b/conmon-rs/server/src/container_log/json.rs
@@ -1,12 +1,11 @@
 use crate::container_io::Pipe;
 use anyhow::{Context, Result};
+use memchr::memchr;
 use serde::Serialize;
+use std::fs::{File, OpenOptions};
+use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
-use tokio::{
-    fs::{File, OpenOptions},
-    io::{AsyncBufRead, AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter},
-};
 use tracing::debug;
 
 /// Log entry structure for JSON serialization
@@ -49,25 +48,34 @@ impl JsonLogger {
             file: None,
             max_log_size,
             bytes_written: 0,
-            line_buf: Vec::with_capacity(256), // Pre-allocate for typical log lines
-            json_buf: Vec::with_capacity(512), // Pre-allocate for JSON output
+            line_buf: Vec::with_capacity(256),
+            json_buf: Vec::with_capacity(512),
         })
     }
 
-    pub async fn init(&mut self) -> Result<()> {
+    pub fn init(&mut self) -> Result<()> {
         debug!("Initializing JSON logger in path {}", self.path().display());
-        self.set_file(Self::open(self.path()).await?.into());
+        self.set_file(Self::open(self.path())?.into());
         Ok(())
     }
 
-    pub async fn write<T>(&mut self, pipe: Pipe, bytes: T) -> Result<()>
-    where
-        T: AsyncBufRead + Unpin,
-    {
-        let mut reader = BufReader::new(bytes);
+    pub fn write(&mut self, pipe: Pipe, data: &[u8]) -> Result<()> {
+        let mut remaining = data;
+        loop {
+            self.line_buf.clear();
+            let consumed = match memchr(b'\n', remaining) {
+                Some(i) => {
+                    self.line_buf.extend_from_slice(&remaining[..=i]);
+                    i + 1
+                }
+                None if !remaining.is_empty() => {
+                    self.line_buf.extend_from_slice(remaining);
+                    remaining.len()
+                }
+                None => break,
+            };
+            remaining = &remaining[consumed..];
 
-        while reader.read_until(b'\n', &mut self.line_buf).await? > 0 {
-            // Get Unix timestamp in seconds (more efficient than Debug format)
             let timestamp = SystemTime::now()
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .unwrap_or_default()
@@ -78,18 +86,15 @@ impl JsonLogger {
                 Pipe::StdErr => "stderr",
             };
 
-            // Convert message to UTF-8, trim whitespace
             let message = String::from_utf8_lossy(&self.line_buf);
             let message_trimmed = message.trim();
 
-            // Create log entry struct
             let log_entry = LogEntry {
                 timestamp,
                 pipe: pipe_str,
                 message: message_trimmed,
             };
 
-            // Serialize directly to reusable buffer to avoid String allocation
             self.json_buf.clear();
             serde_json::to_writer(&mut self.json_buf, &log_entry).context("serialize log entry")?;
 
@@ -98,43 +103,39 @@ impl JsonLogger {
             #[allow(clippy::collapsible_if)]
             if let Some(max_size) = self.max_log_size {
                 if self.bytes_written > max_size {
-                    self.reopen().await?;
+                    self.reopen()?;
                     self.bytes_written = 0;
                 }
             }
 
             let file = self.file.as_mut().context(Self::ERR_UNINITIALIZED)?;
-            file.write_all(&self.json_buf).await?;
-            file.write_all(b"\n").await?;
-            self.line_buf.clear();
+            file.write_all(&self.json_buf)?;
+            file.write_all(b"\n")?;
         }
 
-        // Flush once at the end instead of per-line to reduce syscall overhead
-        self.flush().await?;
+        self.flush()?;
         Ok(())
     }
 
-    pub async fn reopen(&mut self) -> Result<()> {
+    pub fn reopen(&mut self) -> Result<()> {
         debug!("Reopen JSON log {}", self.path().display());
         self.file
             .as_mut()
             .context(Self::ERR_UNINITIALIZED)?
             .get_ref()
-            .sync_all()
-            .await?;
-        self.init().await
+            .sync_all()?;
+        self.init()
     }
 
-    pub async fn flush(&mut self) -> Result<()> {
+    pub fn flush(&mut self) -> Result<()> {
         self.file
             .as_mut()
             .context(Self::ERR_UNINITIALIZED)?
             .flush()
-            .await
             .context("flush file writer")
     }
 
-    async fn open<T: AsRef<Path>>(path: T) -> Result<BufWriter<File>> {
+    fn open<T: AsRef<Path>>(path: T) -> Result<BufWriter<File>> {
         Ok(BufWriter::new(
             OpenOptions::new()
                 .create(true)
@@ -142,7 +143,6 @@ impl JsonLogger {
                 .truncate(true)
                 .write(true)
                 .open(&path)
-                .await
                 .with_context(|| format!("open log file path '{}'", path.as_ref().display()))?,
         ))
     }
@@ -151,62 +151,49 @@ impl JsonLogger {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Cursor;
-    use tokio::io::AsyncReadExt;
+    use std::fs;
 
-    #[tokio::test]
-    async fn test_json_logger_new() {
+    #[test]
+    fn test_json_logger_new() {
         let logger = JsonLogger::new("/tmp/test.log", Some(1000)).unwrap();
         assert_eq!(logger.path().to_str().unwrap(), "/tmp/test.log");
         assert_eq!(logger.max_log_size.unwrap(), 1000);
     }
 
-    #[tokio::test]
-    async fn test_json_logger_init() {
+    #[test]
+    fn test_json_logger_init() {
         let mut logger = JsonLogger::new("/tmp/test_init.log", Some(1000)).unwrap();
-        logger.init().await.unwrap();
+        logger.init().unwrap();
         assert!(logger.file.is_some());
     }
 
-    #[tokio::test]
-    async fn test_json_logger_write() {
+    #[test]
+    fn test_json_logger_write() {
         let mut logger = JsonLogger::new("/tmp/test_write.log", Some(1000)).unwrap();
-        logger.init().await.unwrap();
+        logger.init().unwrap();
 
-        let cursor = Cursor::new(b"Test log message\n".to_vec());
-        logger.write(Pipe::StdOut, cursor).await.unwrap();
+        logger.write(Pipe::StdOut, b"Test log message\n").unwrap();
 
-        // Read back from the file
-        let mut file = File::open("/tmp/test_write.log").await.unwrap();
-        let mut contents = String::new();
-        file.read_to_string(&mut contents).await.unwrap();
-
-        // Check if the file contains the logged message
+        let contents = fs::read_to_string("/tmp/test_write.log").unwrap();
         assert!(contents.contains("Test log message"));
     }
 
-    #[tokio::test]
-    async fn test_json_logger_reopen() {
+    #[test]
+    fn test_json_logger_reopen() {
         let mut logger = JsonLogger::new("/tmp/test_reopen.log", Some(1000)).unwrap();
-        logger.init().await.unwrap();
+        logger.init().unwrap();
 
-        // Write to the file
-        let cursor = Cursor::new(b"Test log message before reopen\n".to_vec());
-        logger.write(Pipe::StdOut, cursor).await.unwrap();
+        logger
+            .write(Pipe::StdOut, b"Test log message before reopen\n")
+            .unwrap();
 
-        // Reopen the file
-        logger.reopen().await.unwrap();
+        logger.reopen().unwrap();
 
-        // Write to the file again
-        let cursor = Cursor::new(b"Test log message after reopen\n".to_vec());
-        logger.write(Pipe::StdOut, cursor).await.unwrap();
+        logger
+            .write(Pipe::StdOut, b"Test log message after reopen\n")
+            .unwrap();
 
-        // Read back from the file
-        let mut file = File::open("/tmp/test_reopen.log").await.unwrap();
-        let mut contents = String::new();
-        file.read_to_string(&mut contents).await.unwrap();
-
-        // Check if the file contains the logged message
+        let contents = fs::read_to_string("/tmp/test_reopen.log").unwrap();
         assert!(contents.contains("Test log message after reopen"));
         assert!(!contents.contains("Test log message before reopen"));
     }

--- a/conmon-rs/server/src/container_log/mod.rs
+++ b/conmon-rs/server/src/container_log/mod.rs
@@ -6,16 +6,42 @@ use crate::{
     container_io::Pipe, container_log::cri::CriLogger, container_log::journald::JournaldLogger,
     container_log::json::JsonLogger,
 };
-use anyhow::Result;
+use anyhow::{Context, Result};
 use capnp::struct_list::Reader;
 use conmon_common::conmon_capnp::conmon::log_driver::{Owned, Type};
 use std::sync::Arc;
-use tokio::{io::AsyncBufRead, sync::RwLock};
+use tokio::task;
+use tracing::error;
 
-pub type SharedContainerLog = Arc<RwLock<ContainerLog>>;
+/// Messages sent to the log writer task.
+enum LogMessage {
+    /// Log data from a pipe.
+    Data(Pipe, Arc<[u8]>),
+    /// Reopen all log files (for log rotation).
+    Reopen(tokio::sync::oneshot::Sender<Result<()>>),
+}
+
+impl std::fmt::Debug for LogMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Data(pipe, data) => f
+                .debug_tuple("Data")
+                .field(pipe)
+                .field(&data.len())
+                .finish(),
+            Self::Reopen(_) => f.debug_tuple("Reopen").finish(),
+        }
+    }
+}
+
+/// A channel-based handle to the log writer task.
+#[derive(Clone, Debug, Default)]
+pub struct SharedContainerLog {
+    sender: Option<async_channel::Sender<LogMessage>>,
+}
 
 #[derive(Debug, Default)]
-pub struct ContainerLog {
+struct ContainerLog {
     drivers: Vec<LogDriver>,
 }
 
@@ -26,14 +52,15 @@ enum LogDriver {
     Json(JsonLogger),
 }
 
-impl ContainerLog {
-    /// Create a new default SharedContainerLog.
-    pub fn new() -> SharedContainerLog {
-        Arc::new(RwLock::new(Self::default()))
+impl SharedContainerLog {
+    /// Create a new SharedContainerLog with no drivers (no-op logger).
+    pub fn new() -> Self {
+        Self::default()
     }
 
-    /// Create a new SharedContainerLog from an owned reader.
-    pub fn from(reader: Reader<Owned>) -> Result<SharedContainerLog> {
+    /// Create a new SharedContainerLog from log driver configuration.
+    /// Parses drivers, opens log files, and spawns the writer task.
+    pub fn from(reader: Reader<Owned>) -> Result<Self> {
         let drivers = reader
             .iter()
             .map(|x| -> Result<_> {
@@ -66,45 +93,109 @@ impl ContainerLog {
                 }
             })
             .collect::<Result<Vec<_>>>()?;
-        Ok(Arc::new(RwLock::new(Self { drivers })))
+
+        if drivers.is_empty() {
+            return Ok(Self::new());
+        }
+
+        let mut log = ContainerLog { drivers };
+        log.init()?;
+
+        let (sender, receiver) = async_channel::bounded(256);
+        task::spawn(Self::writer_loop(log, receiver));
+
+        Ok(Self {
+            sender: Some(sender),
+        })
     }
 
-    /// Asynchronously initialize all loggers.
-    pub async fn init(&mut self) -> Result<()> {
+    /// Send log data to the writer task.
+    pub async fn send(&self, pipe: Pipe, data: Arc<[u8]>) -> Result<()> {
+        if let Some(sender) = &self.sender {
+            sender
+                .send(LogMessage::Data(pipe, data))
+                .await
+                .context("send log data to writer")?;
+        }
+        Ok(())
+    }
+
+    /// Request the writer task to reopen all log files.
+    pub async fn reopen(&self) -> Result<()> {
+        if let Some(sender) = &self.sender {
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            sender
+                .send(LogMessage::Reopen(tx))
+                .await
+                .context("send reopen message to writer")?;
+            rx.await.context("receive reopen result")??;
+        }
+        Ok(())
+    }
+
+    async fn writer_loop(mut log: ContainerLog, receiver: async_channel::Receiver<LogMessage>) {
+        while let Ok(msg) = receiver.recv().await {
+            match msg {
+                LogMessage::Data(pipe, data) => {
+                    if let Err(e) = log.write(pipe, &data) {
+                        error!("Log write error: {:#}", e);
+                    }
+                }
+                LogMessage::Reopen(reply) => {
+                    let _ = reply.send(log.reopen());
+                }
+            }
+        }
+        if let Err(e) = log.flush() {
+            error!("Log flush error on shutdown: {:#}", e);
+        }
+    }
+}
+
+impl ContainerLog {
+    /// Initialize all loggers.
+    fn init(&mut self) -> Result<()> {
         for driver in &mut self.drivers {
             match driver {
-                LogDriver::ContainerRuntimeInterface(logger) => logger.init().await?,
-                LogDriver::Json(logger) => logger.init().await?,
-                LogDriver::Journald(logger) => logger.init().await?,
+                LogDriver::ContainerRuntimeInterface(logger) => logger.init()?,
+                LogDriver::Json(logger) => logger.init()?,
+                LogDriver::Journald(logger) => logger.init()?,
             }
         }
         Ok(())
     }
 
     /// Reopen the container logs.
-    pub async fn reopen(&mut self) -> Result<()> {
+    fn reopen(&mut self) -> Result<()> {
         for driver in &mut self.drivers {
             match driver {
-                LogDriver::ContainerRuntimeInterface(logger) => logger.reopen().await?,
-                LogDriver::Json(logger) => logger.reopen().await?,
-                LogDriver::Journald(logger) => logger.reopen().await?,
+                LogDriver::ContainerRuntimeInterface(logger) => logger.reopen()?,
+                LogDriver::Json(logger) => logger.reopen()?,
+                LogDriver::Journald(logger) => logger.reopen()?,
             }
         }
         Ok(())
     }
 
-    /// Write the contents of the provided reader into all loggers.
-    pub async fn write<T>(&mut self, pipe: Pipe, bytes: T) -> Result<()>
-    where
-        T: AsyncBufRead + Unpin + Clone,
-    {
+    /// Write data to all log drivers.
+    fn write(&mut self, pipe: Pipe, data: &[u8]) -> Result<()> {
         for driver in &mut self.drivers {
             match driver {
-                LogDriver::ContainerRuntimeInterface(logger) => {
-                    logger.write(pipe, bytes.clone()).await?
-                }
-                LogDriver::Journald(logger) => logger.write(pipe, bytes.clone()).await?,
-                LogDriver::Json(logger) => logger.write(pipe, bytes.clone()).await?,
+                LogDriver::ContainerRuntimeInterface(logger) => logger.write(pipe, data)?,
+                LogDriver::Journald(logger) => logger.write(pipe, data)?,
+                LogDriver::Json(logger) => logger.write(pipe, data)?,
+            }
+        }
+        Ok(())
+    }
+
+    /// Flush all file-based log drivers.
+    fn flush(&mut self) -> Result<()> {
+        for driver in &mut self.drivers {
+            match driver {
+                LogDriver::ContainerRuntimeInterface(logger) => logger.flush()?,
+                LogDriver::Json(logger) => logger.flush()?,
+                LogDriver::Journald(_) => {}
             }
         }
         Ok(())

--- a/conmon-rs/server/src/rpc.rs
+++ b/conmon-rs/server/src/rpc.rs
@@ -4,7 +4,7 @@ use crate::{
     capnp_util,
     child::Child,
     container_io::{ContainerIO, SharedContainerIO},
-    container_log::ContainerLog,
+    container_log::SharedContainerLog,
     pause::Pause,
     server::{GenerateRuntimeArgs, Server},
     version::Version,
@@ -137,7 +137,7 @@ impl conmon::Server for Server {
         debug!("Got a create container request");
 
         let log_drivers = pry!(req.get_log_drivers());
-        let container_log = pry_err!(ContainerLog::from(log_drivers));
+        let container_log = pry_err!(SharedContainerLog::from(log_drivers));
         let mut container_io =
             pry_err!(ContainerIO::new(req.get_terminal(), container_log.clone()));
 
@@ -168,8 +168,6 @@ impl conmon::Server for Server {
 
         Promise::from_future(
             async move {
-                capnp_err!(container_log.write().await.init().await)?;
-
                 let (grandchild_pid, token) = capnp_err!(match child_reaper
                     .create_child(
                         runtime,
@@ -243,7 +241,7 @@ impl conmon::Server for Server {
         let runtime = self.config().runtime().clone();
         let child_reaper = self.reaper().clone();
 
-        let logger = ContainerLog::new();
+        let logger = SharedContainerLog::new();
         let mut container_io = pry_err!(ContainerIO::new(req.get_terminal(), logger));
 
         let command = pry!(req.get_command());
@@ -376,7 +374,7 @@ impl conmon::Server for Server {
         let child = pry_err!(self.reaper().get(id));
 
         Promise::from_future(
-            async move { capnp_err!(child.io().logger().await.write().await.reopen().await) }
+            async move { capnp_err!(child.io().logger().await.reopen().await) }
                 .instrument(debug_span!("promise")),
         )
     }
@@ -512,7 +510,7 @@ impl conmon::Server for Server {
 
         let streaming_server = self.streaming_server().clone();
         let child_reaper = self.reaper().clone();
-        let container_io = pry_err!(ContainerIO::new(tty, ContainerLog::new()));
+        let container_io = pry_err!(ContainerIO::new(tty, SharedContainerLog::new()));
         let config = self.config().clone();
         let cgroup_manager = pry!(req.get_cgroup_manager());
 

--- a/conmon-rs/server/src/streams.rs
+++ b/conmon-rs/server/src/streams.rs
@@ -117,7 +117,7 @@ impl Streams {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::container_log::ContainerLog;
+    use crate::container_log::SharedContainerLog;
     use anyhow::{Context, bail};
     use std::{process::Stdio, str::from_utf8};
     use tokio::process::Command;
@@ -131,7 +131,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn new_success() -> Result<()> {
-        let logger = ContainerLog::new();
+        let logger = SharedContainerLog::new();
         let attach = SharedContainerAttach::default();
         let token = CancellationToken::new();
 

--- a/conmon-rs/server/src/terminal.rs
+++ b/conmon-rs/server/src/terminal.rs
@@ -283,13 +283,13 @@ impl Drop for Terminal {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::container_log::ContainerLog;
+    use crate::container_log::SharedContainerLog;
     use nix::pty;
     use sendfd::SendWithFd;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn new_success() -> Result<()> {
-        let logger = ContainerLog::new();
+        let logger = SharedContainerLog::new();
         let attach = SharedContainerAttach::default();
         let token = CancellationToken::new();
 


### PR DESCRIPTION
/kind cleanup

#### What type of PR is this?

#### What this PR does / why we need it:
- Replace `Arc<RwLock<ContainerLog>>` with a channel-based architecture using a dedicated `spawn_blocking` writer task, eliminating RwLock contention between stdout and stderr streams
- Switch all log drivers from `tokio::fs` to `std::fs`, removing per-call `spawn_blocking` overhead since the writer task already runs on the blocking thread pool
- Change logger APIs from `AsyncBufRead` generics to `&[u8]` slices, eliminating `BufReader` wrapping and per-driver cloning
- Compose full CRI log lines into a single buffer before writing, reducing 4-5 separate `write_all` calls per line to one

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```