### PR TITLE
perf: journald spawn_blocking, broadcast capacity

### DIFF
--- a/conmon-rs/server/src/attach.rs
+++ b/conmon-rs/server/src/attach.rs
@@ -39,8 +39,8 @@ pub struct SharedContainerAttach {
 
 impl Default for SharedContainerAttach {
     fn default() -> Self {
-        let (read_half_tx, read_half_rx) = broadcast::channel(2);
-        let (write_half_tx, _) = broadcast::channel(2);
+        let (read_half_tx, read_half_rx) = broadcast::channel(16);
+        let (write_half_tx, _) = broadcast::channel(16);
         Self {
             read_half_rx,
             read_half_tx,

--- a/conmon-rs/server/src/container_log/journald.rs
+++ b/conmon-rs/server/src/container_log/journald.rs
@@ -1,7 +1,10 @@
 use crate::{container_io::Pipe, journal::Journal};
 use anyhow::{Context, Result};
 use std::io::Write;
-use tokio::io::{AsyncBufRead, AsyncBufReadExt};
+use tokio::{
+    io::{AsyncBufRead, AsyncBufReadExt},
+    task,
+};
 use tracing::debug;
 
 #[derive(Debug)]
@@ -23,12 +26,15 @@ impl JournaldLogger {
     {
         let mut line_buf = String::new();
         while bytes.read_line(&mut line_buf).await? > 0 {
-            Journal
-                .write_all(line_buf.as_bytes())
-                .context("write to journal")?;
-            line_buf.clear();
+            let line = std::mem::take(&mut line_buf);
+            task::spawn_blocking(move || {
+                Journal
+                    .write_all(line.as_bytes())
+                    .context("write to journal")
+            })
+            .await
+            .context("journal spawn_blocking")??;
         }
-
         Ok(())
     }
 
@@ -61,8 +67,6 @@ mod tests {
 
         let cursor = Cursor::new(b"Test log message\n".to_vec());
         assert!(logger.write(Pipe::StdOut, cursor).await.is_ok());
-
-        // Verifying the actual log message in Journald might require additional setup or permissions.
     }
 
     #[tokio::test]
@@ -77,7 +81,5 @@ mod tests {
 
         let cursor = Cursor::new(b"Test log message after reopen\n".to_vec());
         assert!(logger.write(Pipe::StdOut, cursor).await.is_ok());
-
-        // As with the write test, verifying the actual log messages in Journald might require additional setup or permissions.
     }
 }

--- a/conmon-rs/server/src/streams.rs
+++ b/conmon-rs/server/src/streams.rs
@@ -65,11 +65,9 @@ impl Streams {
         token: CancellationToken,
     ) {
         debug!("Start reading from IO streams");
-        let logger = self.logger().clone();
-        let attach = self.attach().clone();
-        let message_tx = self.message_tx_stdout().clone();
 
         if let Some(stdin) = stdin {
+            let attach = self.attach().clone();
             task::spawn(
                 async move {
                     if let Err(e) = ContainerIO::read_loop_stdin(stdin, attach, token).await {
@@ -80,8 +78,10 @@ impl Streams {
             );
         }
 
-        let attach = self.attach().clone();
         if let Some(stdout) = stdout {
+            let logger = self.logger().clone();
+            let attach = self.attach().clone();
+            let message_tx = self.message_tx_stdout().clone();
             task::spawn(
                 async move {
                     if let Err(e) =
@@ -95,10 +95,10 @@ impl Streams {
             );
         }
 
-        let logger = self.logger().clone();
-        let attach = self.attach().clone();
-        let message_tx = self.message_tx_stderr().clone();
         if let Some(stderr) = stderr {
+            let logger = self.logger().clone();
+            let attach = self.attach().clone();
+            let message_tx = self.message_tx_stderr().clone();
             task::spawn(
                 async move {
                     if let Err(e) =


### PR DESCRIPTION
/kind cleanup

#### What type of PR is this?

#### What this PR does / why we need it:
- Wrap journald `journal_print()` calls in per-line `task::spawn_blocking` to prevent blocking tokio worker threads while preserving streaming semantics
- Increase attach broadcast channel capacity from 2 to 16 to reduce message loss with multiple attach clients
- Move `clone()` calls for logger, attach, and message channels inside stream guards to avoid unnecessary allocations when streams are `None`

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```