### PR TITLE
perf: make OpenTelemetry dependencies optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-release-static-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-release-static-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/Cargo.toml') }}
       - run: .github/install-deps
       - name: Select Toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9

--- a/conmon-rs/server/Cargo.toml
+++ b/conmon-rs/server/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [dependencies]
 anyhow = { version = "1.0.102", default-features = false }
 async-channel = { version = "2.5.0", default-features = false, features = ["std"] }
-axum = { version = "0.8.8", default-features = false, features = ["http2", "tokio", "ws"] }
+axum = { version = "0.8.8", default-features = false, features = ["http1", "http2", "tokio", "ws"] }
 capnp = { version = "0.25.5", default-features = false }
 capnp-rpc = { version = "0.25.1", default-features = false }
 clap = { version = "4.6.0", default-features = false, features = ["cargo", "derive", "env", "error-context", "help", "std", "usage"] }
@@ -27,10 +27,10 @@ lru = { version = "0.18.0", default-features = false }
 memchr = { version = "2.8.1", default-features = false }
 nix = { version = "0.31.3", default-features = false, features = ["fs", "hostname", "mount", "sched", "signal", "socket", "term", "user"] }
 notify = { version = "8.2.0", default-features = false }
-opentelemetry = { version = "0.32.0", default-features = false }
-opentelemetry_sdk = { version = "0.32.1", default-features = false, features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.32.0", default-features = false, features = ["grpc-tonic", "trace"] }
-opentelemetry-semantic-conventions = { version = "0.32.0", default-features = false, features = ["semconv_experimental"] }
+opentelemetry = { version = "0.32.0", default-features = false, optional = true }
+opentelemetry_sdk = { version = "0.32.1", default-features = false, features = ["rt-tokio"], optional = true }
+opentelemetry-otlp = { version = "0.32.0", default-features = false, features = ["grpc-tonic", "trace"], optional = true }
+opentelemetry-semantic-conventions = { version = "0.32.0", default-features = false, features = ["semconv_experimental"], optional = true }
 sendfd = { version = "0.4.4", default-features = false, features = ["tokio"] }
 serde = { version = "1.0.228", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.150", default-features = false, features = ["std"] }
@@ -42,10 +42,20 @@ tokio-seqpacket = { version = "0.8.2", default-features = false }
 tokio-util = { version = "0.7.18", default-features = false, features = ["compat"] }
 tower-http = { version = "0.6.11", default-features = false, features = ["trace"] }
 tracing = { version = "0.1.44", default-features = false }
-tracing-opentelemetry = { version = "0.33.0", default-features = false }
+tracing-opentelemetry = { version = "0.33.0", default-features = false, optional = true }
 tracing-subscriber = { version = "0.3.23", default-features = false, features = ["fmt"] }
 time = { version = "0.3.47", default-features = false, features = ["formatting", "local-offset", "parsing", "std"] }
 uuid = { version = "1.23.2", default-features = false, features = ["v4", "fast-rng"] }
+
+[features]
+default = []
+tracing = [
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-otlp",
+    "dep:opentelemetry-semantic-conventions",
+    "dep:tracing-opentelemetry",
+]
 
 [dev-dependencies]
 mockall = { version = "0.14.0", default-features = false }

--- a/conmon-rs/server/src/config.rs
+++ b/conmon-rs/server/src/config.rs
@@ -110,6 +110,7 @@ pub struct Config {
     /// (ignored for backwards compatibility)
     cgroup_manager: String,
 
+    #[cfg_attr(not(feature = "tracing"), allow(dead_code))]
     #[arg(
         env(concat!(prefix!(), "ENABLE_TRACING")),
         long("enable-tracing"),
@@ -118,6 +119,7 @@ pub struct Config {
     /// Enable OpenTelemetry tracing.
     enable_tracing: bool,
 
+    #[cfg_attr(not(feature = "tracing"), allow(dead_code))]
     #[arg(
         default_value("http://127.0.0.1:4317"),
         env(concat!(prefix!(), "TRACING_ENDPOINT")),
@@ -176,11 +178,13 @@ impl Config {
     }
 
     /// Enable OpenTelemetry tracing.
+    #[cfg(feature = "tracing")]
     pub fn enable_tracing(&self) -> bool {
         self.enable_tracing
     }
 
     /// OpenTelemetry GRPC endpoint.
+    #[cfg(feature = "tracing")]
     pub fn tracing_endpoint(&self) -> &str {
         &self.tracing_endpoint
     }

--- a/conmon-rs/server/src/lib.rs
+++ b/conmon-rs/server/src/lib.rs
@@ -32,6 +32,7 @@ mod rpc;
 mod server;
 mod streaming_server;
 mod streams;
+#[cfg(feature = "tracing")]
 mod telemetry;
 #[allow(unsafe_code)]
 mod terminal;

--- a/conmon-rs/server/src/rpc.rs
+++ b/conmon-rs/server/src/rpc.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "tracing")]
+use crate::telemetry::Telemetry;
 use crate::{
     capnp_util,
     child::Child,
@@ -5,7 +7,6 @@ use crate::{
     container_log::ContainerLog,
     pause::Pause,
     server::{GenerateRuntimeArgs, Server},
-    telemetry::Telemetry,
     version::Version,
 };
 use anyhow::{Context, format_err};
@@ -33,6 +34,20 @@ macro_rules! capnp_err {
     ($x:expr_2021) => {
         $x.map_err(|e| Error::failed(format!("{:#}", e)))
     };
+}
+
+#[cfg(feature = "tracing")]
+fn set_parent_context(
+    reader: capnp::struct_list::Reader<'_, conmon::text_text_map_entry::Owned>,
+) -> Result<(), Error> {
+    Telemetry::set_parent_context(reader).map_err(|e| Error::failed(format!("{:#}", e)))
+}
+
+#[cfg(not(feature = "tracing"))]
+fn set_parent_context(
+    _reader: capnp::struct_list::Reader<'_, conmon::text_text_map_entry::Owned>,
+) -> Result<(), Error> {
+    Ok(())
 }
 
 macro_rules! new_root_span {
@@ -87,7 +102,7 @@ impl conmon::Server for Server {
 
         let span = debug_span!("version", uuid = %Uuid::new_v4());
         let _enter = span.enter();
-        pry_err!(Telemetry::set_parent_context(pry!(req.get_metadata())));
+        pry!(set_parent_context(pry!(req.get_metadata())));
 
         let version = Version::new(req.get_verbose());
         let mut response = results.get().init_response();
@@ -115,7 +130,7 @@ impl conmon::Server for Server {
 
         let span = new_root_span!("create_container", id.as_str());
         let _enter = span.enter();
-        pry_err!(Telemetry::set_parent_context(pry!(req.get_metadata())));
+        pry!(set_parent_context(pry!(req.get_metadata())));
 
         let cleanup_cmd: Vec<String> = capnp_vec_str!(req.get_cleanup_cmd());
 
@@ -216,7 +231,7 @@ impl conmon::Server for Server {
 
         let span = new_root_span!("exec_sync_container", id.as_str());
         let _enter = span.enter();
-        pry_err!(Telemetry::set_parent_context(pry!(req.get_metadata())));
+        pry!(set_parent_context(pry!(req.get_metadata())));
 
         let timeout = req.get_timeout_sec();
 
@@ -315,7 +330,7 @@ impl conmon::Server for Server {
 
         let span = new_root_span!("attach_container", id);
         let _enter = span.enter();
-        pry_err!(Telemetry::set_parent_context(pry!(req.get_metadata())));
+        pry!(set_parent_context(pry!(req.get_metadata())));
 
         debug!("Got a attach container request",);
 
@@ -354,7 +369,7 @@ impl conmon::Server for Server {
 
         let span = new_root_span!("reopen_log_container", id);
         let _enter = span.enter();
-        pry_err!(Telemetry::set_parent_context(pry!(req.get_metadata())));
+        pry!(set_parent_context(pry!(req.get_metadata())));
 
         debug!("Got a reopen container log request");
 
@@ -377,7 +392,7 @@ impl conmon::Server for Server {
 
         let span = new_root_span!("set_window_size_container", id);
         let _enter = span.enter();
-        pry_err!(Telemetry::set_parent_context(pry!(req.get_metadata())));
+        pry!(set_parent_context(pry!(req.get_metadata())));
 
         debug!("Got a set window size container request");
 
@@ -407,7 +422,7 @@ impl conmon::Server for Server {
 
         let span = new_root_span!("create_namespaces", pod_id);
         let _enter = span.enter();
-        pry_err!(Telemetry::set_parent_context(pry!(req.get_metadata())));
+        pry!(set_parent_context(pry!(req.get_metadata())));
 
         let pause = pry_err!(Pause::init_shared(
             pry!(pry!(req.get_base_path()).to_str()),
@@ -447,7 +462,7 @@ impl conmon::Server for Server {
             uuid = %Uuid::new_v4()
         );
         let _enter = span.enter();
-        pry_err!(Telemetry::set_parent_context(pry!(req.get_metadata())));
+        pry!(set_parent_context(pry!(req.get_metadata())));
 
         debug!("Got a start fd socket request");
 
@@ -480,7 +495,7 @@ impl conmon::Server for Server {
             uuid = %Uuid::new_v4()
         );
         let _enter = span.enter();
-        pry_err!(Telemetry::set_parent_context(pry!(req.get_metadata())));
+        pry!(set_parent_context(pry!(req.get_metadata())));
 
         let id = pry_err!(pry_err!(req.get_id()).to_string());
 
@@ -548,7 +563,7 @@ impl conmon::Server for Server {
             uuid = %Uuid::new_v4()
         );
         let _enter = span.enter();
-        pry_err!(Telemetry::set_parent_context(pry!(req.get_metadata())));
+        pry!(set_parent_context(pry!(req.get_metadata())));
 
         let id = pry_err!(pry_err!(req.get_id()).to_str());
         let (stdin, stdout, stderr) = (req.get_stdin(), req.get_stdout(), req.get_stderr());
@@ -593,7 +608,7 @@ impl conmon::Server for Server {
             uuid = %Uuid::new_v4()
         );
         let _enter = span.enter();
-        pry_err!(Telemetry::set_parent_context(pry!(req.get_metadata())));
+        pry!(set_parent_context(pry!(req.get_metadata())));
 
         let net_ns_path = pry_err!(pry_err!(req.get_net_ns_path()).to_string());
         let streaming_server = self.streaming_server().clone();

--- a/conmon-rs/server/src/server.rs
+++ b/conmon-rs/server/src/server.rs
@@ -1,5 +1,7 @@
 #![deny(missing_docs)]
 
+#[cfg(feature = "tracing")]
+use crate::telemetry::Telemetry;
 use crate::{
     child_reaper::ChildReaper,
     config::{Commands, Config, LogDriver, LogLevel, Verbosity},
@@ -10,12 +12,12 @@ use crate::{
     listener::{DefaultListener, Listener},
     pause::Pause,
     streaming_server::StreamingServer,
-    telemetry::Telemetry,
     version::Version,
 };
 use anyhow::{Context, Result, format_err};
 use capnp::text_list::Reader;
 use capnp_rpc::{RpcSystem, rpc_twoparty_capnp::Side, twoparty};
+#[cfg(feature = "tracing")]
 use clap::crate_name;
 use conmon_common::conmon_capnp::conmon::{self, CgroupManager};
 use futures::{AsyncReadExt, FutureExt};
@@ -25,7 +27,9 @@ use nix::{
     sys::signal::Signal,
     unistd::{ForkResult, fork},
 };
+#[cfg(feature = "tracing")]
 use opentelemetry::trace::{FutureExt as OpenTelemetryFutureExt, TracerProvider};
+#[cfg(feature = "tracing")]
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use std::{fs::File, io::Write, path::Path, process, str::FromStr, sync::Arc};
 use tokio::{
@@ -37,6 +41,7 @@ use tokio::{
 };
 use tokio_util::compat::TokioAsyncReadCompatExt;
 use tracing::{Instrument, debug, debug_span, info};
+#[cfg(feature = "tracing")]
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use tracing_subscriber::{filter::LevelFilter, layer::SubscriberExt, prelude::*};
 use twoparty::VatNetwork;
@@ -54,6 +59,7 @@ pub struct Server {
     fd_socket: Arc<FdSocket>,
 
     /// OpenTelemetry tracer instance.
+    #[cfg(feature = "tracing")]
     tracer: Option<SdkTracerProvider>,
 
     /// Streaming server instance.
@@ -77,6 +83,7 @@ impl Server {
     }
 
     /// OpenTelemetry tracer instance.
+    #[cfg(feature = "tracing")]
     pub(crate) fn tracer(&self) -> &Option<SdkTracerProvider> {
         &self.tracer
     }
@@ -92,6 +99,7 @@ impl Server {
             config: Arc::new(Config::default()),
             reaper: Default::default(),
             fd_socket: Default::default(),
+            #[cfg(feature = "tracing")]
             tracer: Default::default(),
             streaming_server: Default::default(),
         };
@@ -162,6 +170,7 @@ impl Server {
             return Err(Errno::last()).context("set child subreaper");
         }
 
+        #[cfg(feature = "tracing")]
         let tracer = self.tracer().clone();
 
         let worker_threads = std::thread::available_parallelism()
@@ -179,6 +188,7 @@ impl Server {
             .build()?;
         rt.block_on(self.spawn_tasks())?;
 
+        #[cfg(feature = "tracing")]
         if let Some(tracer) = tracer {
             tracer.shutdown().context("shutdown tracer")?;
         }
@@ -200,6 +210,7 @@ impl Server {
         let level = LevelFilter::from_str(self.config().log_level().as_ref())
             .context("convert log level filter")?;
 
+        #[cfg(feature = "tracing")]
         let telemetry_layer = if self.config().enable_tracing() {
             let tracer = Telemetry::layer(self.config().tracing_endpoint())
                 .context("build telemetry layer")?;
@@ -213,7 +224,9 @@ impl Server {
             None
         };
 
-        let registry = tracing_subscriber::registry().with(telemetry_layer);
+        let registry = tracing_subscriber::registry();
+        #[cfg(feature = "tracing")]
+        let registry = registry.with(telemetry_layer);
 
         match self.config().log_driver() {
             LogDriver::None => {}
@@ -256,14 +269,21 @@ impl Server {
         let reaper = self.reaper.clone();
 
         let signal_handler_span = debug_span!("signal_handler");
+        #[cfg(feature = "tracing")]
         task::spawn(
             Self::start_signal_handler(reaper, socket, fd_socket, shutdown_tx)
                 .with_context(signal_handler_span.context())
                 .instrument(signal_handler_span),
         );
+        #[cfg(not(feature = "tracing"))]
+        task::spawn(
+            Self::start_signal_handler(reaper, socket, fd_socket, shutdown_tx)
+                .instrument(signal_handler_span),
+        );
 
         let backend_span = debug_span!("backend");
-        task::spawn_blocking(move || {
+        #[cfg(feature = "tracing")]
+        let result = task::spawn_blocking(move || {
             Handle::current().block_on(
                 LocalSet::new()
                     .run_until(self.start_backend(shutdown_rx))
@@ -271,7 +291,17 @@ impl Server {
                     .instrument(backend_span),
             )
         })
-        .await?
+        .await?;
+        #[cfg(not(feature = "tracing"))]
+        let result = task::spawn_blocking(move || {
+            Handle::current().block_on(
+                LocalSet::new()
+                    .run_until(self.start_backend(shutdown_rx))
+                    .instrument(backend_span),
+            )
+        })
+        .await?;
+        result
     }
 
     async fn start_signal_handler<T: AsRef<Path>>(


### PR DESCRIPTION
/kind cleanup

#### What type of PR is this?

#### What this PR does / why we need it:
Move OpenTelemetry dependencies (`opentelemetry`, `opentelemetry_sdk`, `opentelemetry-otlp`, `opentelemetry-semantic-conventions`, `tracing-opentelemetry`) behind a `tracing` feature flag (disabled by default). Builds without the feature exclude the entire gRPC/tonic/protobuf stack, reducing binary size.
Pass `--features tracing` to build with OpenTelemetry support.
Also adds `Cargo.toml` to the CI cache key to invalidate stale build artifacts when feature flags change.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
OpenTelemetry tracing support is now behind an opt-in `tracing` cargo feature flag. Builds that use `--enable-tracing` at runtime must be compiled with `--features tracing`.
```