### PR TITLE
Remove deprecated --cgroup-manager CLI flag

### DIFF
--- a/conmon-rs/server/src/config.rs
+++ b/conmon-rs/server/src/config.rs
@@ -105,10 +105,6 @@ pub struct Config {
     /// Do not fork if true.
     skip_fork: bool,
 
-    #[arg(default_value(""), long("cgroup-manager"), short('c'), hide(true))]
-    /// Ignored for backwards compatibility with older CRI-O versions.
-    cgroup_manager: String,
-
     #[cfg_attr(not(feature = "tracing"), allow(dead_code))]
     #[arg(
         env(concat!(prefix!(), "ENABLE_TRACING")),


### PR DESCRIPTION
/kind cleanup

#### What type of PR is this?

Cleanup

#### What this PR does / why we need it:

Removes the hidden `--cgroup-manager` CLI flag that was kept for backwards compatibility with older CRI-O versions. Now that CRI-O has vendored the v1.0.0 pre-release (cri-o/cri-o#10033), the flag is no longer needed.

#### Which issue(s) this PR fixes:

Part of #3270

#### Special notes for your reviewer:

Per https://github.com/containers/conmon-rs/pull/3269#discussion_r3378558737

#### Does this PR introduce a user-facing change?

```release-note
Remove deprecated `--cgroup-manager` CLI flag.
```