### PR TITLE
Remove unnecessary cross build dependencies

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,14 +1,2 @@
 [build]
-pre-build = ["apt-get update && apt-get install -y capnproto protobuf-compiler libz-dev"]
-
-[target.i686-unknown-linux-gnu]
-pre-build = ["dpkg --add-architecture i386 && apt-get update && apt-get install -y capnproto protobuf-compiler libz-dev:i386"]
-
-[target.aarch64-unknown-linux-gnu]
-pre-build = ["dpkg --add-architecture arm64 && apt-get update && apt-get install -y capnproto protobuf-compiler libz-dev:arm64"]
-
-[target.powerpc64le-unknown-linux-gnu]
-pre-build = ["dpkg --add-architecture ppc64el && apt-get update && apt-get install -y capnproto protobuf-compiler libz-dev:ppc64el"]
-
-[target.s390x-unknown-linux-gnu]
-pre-build = ["dpkg --add-architecture s390x && apt-get update && apt-get install -y capnproto protobuf-compiler libz-dev:s390x"]
+pre-build = ["apt-get update && apt-get install -y capnproto"]


### PR DESCRIPTION
/kind cleanup

#### What type of PR is this?

Cleanup

#### What this PR does / why we need it:

The `protobuf-compiler` and `libz-dev` packages in `Cross.toml` were only needed for the `tracing` feature (OpenTelemetry/tonic/prost), but the cross build does not enable it. Without tracing, there are no protobuf or zlib dependencies, so only `capnproto` (a host build tool for Cap'n Proto schema compilation) is required.

Removing the unnecessary packages also fixes the s390x and ppc64el cross builds, which broke when the cross-rs base images moved to Ubuntu Noble where `libz-dev` no longer resolves with cross-architecture qualifiers.

The per-target overrides existed solely to install `libz-dev` with architecture qualifiers and are no longer needed.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```