### PR TITLE
Remove gomod dependabot and group Cargo deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,17 +12,17 @@ updates:
       - dependency-type: direct
       - dependency-type: indirect
     groups:
+      capnp:
+        patterns:
+          - "capnp*"
       opentelemetry:
         patterns:
           - "opentelemetry*"
           - "tracing-opentelemetry"
-  - package-ecosystem: gomod
-    directory: "/"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-    labels:
-      - "release-note-none"
+      rust-dependencies:
+        update-types:
+          - minor
+          - patch
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
/kind cleanup

#### What type of PR is this?

Cleanup

#### What this PR does / why we need it:

- Removes the `gomod` dependabot ecosystem. Go dependencies are manually synced with CRI-O, so automated bumps create noise and risk breaking compatibility.
- Groups Cargo dependencies to reduce PR churn: `capnp*` crates together, `opentelemetry*` crates together (existing), and remaining minor/patch updates in a single catch-all group.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```