### PR TITLE
ci: fix gci lint and get script GCS caching

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -37,11 +37,11 @@ const (
 )
 
 var (
-	errRuntimeUnspecified     = errors.New("runtime must be specified")
-	errRunDirUnspecified      = errors.New("RunDir must be specified")
-	errInvalidValue           = errors.New("invalid value")
-	errRunDirNotCreated       = errors.New("could not create RunDir")
-	errTimeoutWaitForPid      = errors.New("timed out waiting for server PID to disappear")
+	errRuntimeUnspecified = errors.New("runtime must be specified")
+	errRunDirUnspecified  = errors.New("RunDir must be specified")
+	errInvalidValue       = errors.New("invalid value")
+	errRunDirNotCreated   = errors.New("could not create RunDir")
+	errTimeoutWaitForPid  = errors.New("timed out waiting for server PID to disappear")
 )
 
 // ConmonClient is the main client structure of this package.

--- a/scripts/get
+++ b/scripts/get
@@ -110,7 +110,7 @@ download_binary() {
         fi
     elif [[ $COMMIT == "" ]]; then
         echo "Getting latest commit on main"
-        COMMIT=$(curl_retry $BASE_URL/latest-main.txt)
+        COMMIT=$(curl_retry "$BASE_URL/latest-main.txt" -H "Cache-Control: no-cache")
     fi
 
     echo "Found commit: $COMMIT"


### PR DESCRIPTION
/kind ci

#### What this PR does / why we need it:
- Remove extra column-aligned padding in the `var` block of `pkg/client/client.go` to satisfy the `gci` formatter.
- Add `Cache-Control: no-cache` header when fetching `latest-main.txt` from GCS in `scripts/get` to avoid serving stale markers from the 1 hour CDN cache.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
None
```