### PR TITLE
fix: prevent cosign race between main and tag CI uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,9 +89,9 @@ jobs:
           mv target/x86_64-unknown-linux-gnu/release/conmonrs ${{ github.sha }}
       - run: ./${{ github.sha }}/conmonrs -v
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-        if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags')
+        if: github.ref == 'refs/heads/main'
       - name: Sign binary
-        if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags')
+        if: github.ref == 'refs/heads/main'
         run: |
           cd ${{ github.sha }}
           cosign sign-blob -y conmonrs \
@@ -103,11 +103,11 @@ jobs:
           name: conmonrs
           path: ${{ github.sha }}/*
       - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-        if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags')
+        if: github.ref == 'refs/heads/main'
         with:
           credentials_json: ${{ secrets.GCS_CRIO_SA }}
       - uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
-        if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags')
+        if: github.ref == 'refs/heads/main'
         with:
           path: ${{ github.sha }}
           destination: cri-o/conmon-rs
@@ -163,9 +163,9 @@ jobs:
           mkdir ${{ github.sha }}
           cp result/bin/conmonrs ${{ github.sha }}/conmonrs.${{ matrix.arch }}
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-        if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags')
+        if: github.ref == 'refs/heads/main'
       - name: Sign binary
-        if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags')
+        if: github.ref == 'refs/heads/main'
         run: |
           cd ${{ github.sha }}
           cosign sign-blob -y conmonrs.${{ matrix.arch }} \
@@ -177,11 +177,11 @@ jobs:
           name: conmonrs-${{ matrix.arch }}
           path: ${{ github.sha }}/*
       - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-        if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags')
+        if: github.ref == 'refs/heads/main'
         with:
           credentials_json: ${{ secrets.GCS_CRIO_SA }}
       - uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
-        if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags')
+        if: github.ref == 'refs/heads/main'
         with:
           path: ${{ github.sha }}
           destination: cri-o/conmon-rs

--- a/scripts/get
+++ b/scripts/get
@@ -97,30 +97,23 @@ curl_retry() {
 }
 
 download_binary() {
-    GIT_REF=refs/heads/main
-
     if [[ $TAG != "" ]]; then
         echo "Getting commit from tag"
         TAG_JSON=$(curl_retry "https://api.github.com/repos/containers/conmon-rs/git/refs/tags/$TAG")
-        COMMIT=$(echo "$TAG_JSON" | jq -r .object.sha)
-        GIT_REF=$(echo "$TAG_JSON" | jq -r .ref)
-    else
-        if [[ $COMMIT == "" ]]; then
-            echo "Getting latest commit on main"
-            COMMIT=$(curl_retry $BASE_URL/latest-main.txt)
+        TAG_OBJ_TYPE=$(echo "$TAG_JSON" | jq -r .object.type)
+        TAG_OBJ_SHA=$(echo "$TAG_JSON" | jq -r .object.sha)
+        if [[ "$TAG_OBJ_TYPE" == "tag" ]]; then
+            # Annotated tag: dereference to get the commit SHA
+            COMMIT=$(curl_retry "https://api.github.com/repos/containers/conmon-rs/git/tags/$TAG_OBJ_SHA" | jq -r .object.sha)
+        else
+            COMMIT=$TAG_OBJ_SHA
         fi
-
-        # Latest commit can be a tag
-        POSSIBLE_TAG_JSON=$(curl_retry "https://api.github.com/repos/containers/conmon-rs/git/refs/tags" | jq '.[] | select(.object.sha == "'"$COMMIT"'")')
-
-        if [[ $POSSIBLE_TAG_JSON != "" ]]; then
-            GIT_REF=$(echo "$POSSIBLE_TAG_JSON" | jq -r .ref)
-            echo "Commit $COMMIT is tag ref $TAG"
-        fi
+    elif [[ $COMMIT == "" ]]; then
+        echo "Getting latest commit on main"
+        COMMIT=$(curl_retry $BASE_URL/latest-main.txt)
     fi
 
     echo "Found commit: $COMMIT"
-    echo "Using git ref: $GIT_REF"
 
     mkdir -p "$(dirname "$OUTPUT")"
 
@@ -139,6 +132,7 @@ download_binary() {
         done
 
         SLUG=containers/conmon-rs
+        GIT_REF=refs/heads/main
         cosign verify-blob "${FILES[0]}" \
             --certificate-identity "https://github.com/$SLUG/.github/workflows/ci.yml@$GIT_REF" \
             --certificate-oidc-issuer https://token.actions.githubusercontent.com \


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:
When a commit on main is also tagged, both the main and tag CI runs upload
signed artifacts to the same GCS path (`<sha>/`). Since the uploads are
non-atomic and builds embed different timestamps, the binary from one run can
end up paired with the bundle from another, causing cosign verification to fail
with "invalid signature".
This PR restricts signing and GCS uploads to `refs/heads/main` only. Tag pushes
still trigger CI for testing but no longer upload to GCS. The get script is
simplified to always verify against `refs/heads/main`.
Also fixes annotated tag resolution in `scripts/get` when using `-l TAG`: the
git refs API returns the tag object SHA for annotated tags, not the commit SHA.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
The existing broken artifacts in GCS for the v1.0.0 commit will need a main CI
re-run to be overwritten with a consistent binary/bundle pair.

#### Does this PR introduce a user-facing change?
```release-note
Fixed cosign verification in the get script when a commit is both on main and tagged.
```