### PR TITLE
fix: use query parameter for GCS cache busting in get script

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -110,7 +110,7 @@ download_binary() {
         fi
     elif [[ $COMMIT == "" ]]; then
         echo "Getting latest commit on main"
-        COMMIT=$(curl_retry "$BASE_URL/latest-main.txt" -H "Cache-Control: no-cache")
+        COMMIT=$(curl_retry "$BASE_URL/latest-main.txt?ts=$(date +%s)")
     fi
 
     echo "Found commit: $COMMIT"


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:
Replace the `Cache-Control: no-cache` request header with a timestamp query
parameter (`?ts=<epoch>`) when fetching `latest-main.txt` from GCS. The header
alone does not bypass intermediate caches between GitHub Actions runners and
GCS. The query parameter makes each request URL unique, which prevents any
cache layer from serving a stale response.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
None
```