### PR TITLE
server: close file descriptors inherited from the parent

### DIFF
--- a/conmon-rs/server/src/server.rs
+++ b/conmon-rs/server/src/server.rs
@@ -31,7 +31,7 @@ use nix::{
 use opentelemetry::trace::{FutureExt as OpenTelemetryFutureExt, TracerProvider};
 #[cfg(feature = "tracing")]
 use opentelemetry_sdk::trace::SdkTracerProvider;
-use std::{fs::File, io::Write, path::Path, process, str::FromStr, sync::Arc};
+use std::{fs::File, io::Write, os::fd::RawFd, path::Path, process, str::FromStr, sync::Arc};
 use tokio::{
     fs,
     runtime::{Builder, Handle},
@@ -147,6 +147,75 @@ impl Server {
         Ok(server)
     }
 
+    /// Close file descriptors inherited from whatever started us.
+    ///
+    /// conmon-rs daemonizes and outlives the process that spawned it, so any
+    /// descriptor it inherits stays open for the lifetime of the server. If
+    /// the spawning process was itself started with extra descriptors open,
+    /// holding them can keep that process tree from ever finishing - a test
+    /// harness waiting for its own pipe to close, for example.
+    ///
+    /// conmon does the same thing, see `close_all_fds_ge_than(3)` there. Any
+    /// descriptor conmon-rs actually needs is either created after this point
+    /// or received later over the fd socket, so nothing above stderr is worth
+    /// keeping.
+    fn close_inherited_fds() {
+        for fd in Self::inherited_fds() {
+            // The descriptor used to enumerate them is already closed by now,
+            // so check before closing to avoid closing an unrelated descriptor
+            // that reused the number. This runs before tokio starts, so nothing
+            // else can be opening descriptors concurrently.
+            //
+            // These are raw libc calls rather than the `nix` wrappers on
+            // purpose: `BorrowedFd`/`OwnedFd` require the descriptor to be open
+            // for the duration of the borrow, and whether it is still open is
+            // exactly what is unknown here. `fcntl(2)` and `close(2)` take a
+            // plain integer with no such precondition and report `EBADF`.
+            //
+            // SAFETY: both calls are defined for any integer; a stale or
+            // invalid descriptor number fails with `EBADF` rather than
+            // affecting anything else.
+            if unsafe { libc::fcntl(fd, libc::F_GETFD) } != -1 {
+                unsafe { libc::close(fd) };
+            }
+        }
+    }
+
+    /// Every open descriptor above stderr. Split out from `close_inherited_fds`
+    /// so it can be tested without closing the test runner's own descriptors.
+    ///
+    /// This is Linux only: it enumerates `/proc/self/fd` and would report
+    /// nothing at all where that is unavailable, silently leaking the inherited
+    /// descriptors. conmon-rs already requires Linux elsewhere (`prctl`, epoll,
+    /// journald), so the assertion below just makes a port fail here loudly
+    /// rather than lose the behaviour quietly. A log line would not work,
+    /// `close_inherited_fds` runs well before `init_logging`.
+    fn inherited_fds() -> Vec<RawFd> {
+        const {
+            assert!(
+                cfg!(target_os = "linux"),
+                "inherited fds are enumerated through /proc/self/fd, which is Linux only"
+            )
+        };
+
+        let mut fds = Vec::new();
+
+        if let Ok(entries) = std::fs::read_dir("/proc/self/fd") {
+            for entry in entries.flatten() {
+                if let Some(fd) = entry
+                    .file_name()
+                    .to_str()
+                    .and_then(|name| name.parse::<RawFd>().ok())
+                    && fd > 2
+                {
+                    fds.push(fd);
+                }
+            }
+        }
+
+        fds
+    }
+
     /// Start the `Server` instance and consume it.
     pub fn start(self) -> Result<()> {
         // We need to fork as early as possible, especially before setting up tokio.
@@ -163,6 +232,10 @@ impl Server {
                 ForkResult::Child => (),
             }
         }
+
+        // Deliberately outside the `skip_fork` check above: the server outlives
+        // its parent either way, so the descriptors have to go either way.
+        Self::close_inherited_fds();
 
         // now that we've forked, set self to childreaper
         let ret = unsafe { libc::prctl(libc::PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) };
@@ -523,5 +596,30 @@ impl GenerateRuntimeArgs<'_> {
         }
 
         Ok(args)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::fd::AsRawFd;
+
+    #[test]
+    fn inherited_fds_reports_descriptors_above_stderr() -> Result<()> {
+        let file = tempfile::tempfile()?;
+        let fd = file.as_raw_fd();
+
+        let fds = Server::inherited_fds();
+
+        assert!(
+            fds.contains(&fd),
+            "expected an open descriptor {fd} to be reported, got {fds:?}"
+        );
+        // stdin, stdout and stderr are never reported, they are not ours to close.
+        assert!(!fds.contains(&0));
+        assert!(!fds.contains(&1));
+        assert!(!fds.contains(&2));
+
+        Ok(())
     }
 }


### PR DESCRIPTION
### What this PR does

conmon-rs daemonizes and outlives whatever spawned it, so every descriptor it
inherits stays open for the lifetime of the server. If the spawning process was
itself started with extra descriptors open, holding them can stop that process
tree from ever finishing.

This closes everything above stderr right after the daemonizing fork, which is
what `conmon` already does in `close_other_fds()` and `close_all_fds_ge_than(3)`.

### Why

CRI-O's integration suite hits this. bats does not exit until FD 3 is closed by
all of its descendants. The suite backgrounds CRI-O without closing FD 3, CRI-O
spawns conmon-rs, and conmon-rs holds FD 3 for as long as it runs. The suite
then reports every test as passing and hangs until the two hour job timeout.

It only happens on the conmon-rs matrix entry, never conmon — conmon closes
inherited descriptors, conmon-rs did not. Tracked in
https://github.com/cri-o/cri-o/issues/10188, where the full analysis lives.

Observed directly, starting conmon-rs with a pipe on FD 3:

```
=== conmonrs PID 253195 open fds ===
>>> fd 3: /tmp/tmp.PmtQQfFGtB/p
```

### Reproducer

A single bats test that backgrounds conmon-rs and then ends while it is still
running:

```bash
@test "spawn conmonrs and finish the test" {
	D=$(mktemp -d)
	"$CONMONRS_BIN" --runtime /usr/bin/crun --runtime-dir "$D" &>"$D/log" &
	sleep 2
	true
}
```

| conmon-rs build | bats exit | elapsed |
| --- | --- | --- |
| unpatched | 124 | 30s, hung |
| this PR | 0 | 2s |

After the change, FD 3 is conmon-rs's own epoll and no reference to the
inherited pipe remains in its descriptor table.

### Notes for review

- Descriptors conmon-rs needs are either created after this point or received
  later over the fd socket, so nothing above stderr is kept.
- The descriptor used to read `/proc/self/fd` is closed by the time the loop
  runs, so each one is checked with `F_GETFD` before closing to avoid closing an
  unrelated descriptor that reused the number. This runs before tokio starts, so
  nothing else can be opening descriptors concurrently.
- I can switch to `close_range(2)` if you would prefer that over walking
  `/proc/self/fd`; I kept the walk to match what conmon does and to avoid a
  minimum kernel requirement.

### Drafted using Claude


```release-note
None
```