### PR TITLE
Fix gh-pages workflow missing GITHUB_TOKEN

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,6 +5,7 @@ on:
       - main
 env:
   CARGO_TERM_COLOR: always
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
/kind bug

#### What this PR does / why we need it:

The `install-deps` script requires `GITHUB_TOKEN` to fetch the latest crun release from the GitHub API. The `ci.yml` workflow provides it via the top-level `env` block, but `gh-pages.yml` does not, causing the `update` job to fail with `GITHUB_TOKEN: unbound variable`.

This adds the missing `GITHUB_TOKEN` environment variable to align with `ci.yml`.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```